### PR TITLE
Add tests to validate the isFromClient flag on ValueChangeEvents

### DIFF
--- a/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -50,6 +50,7 @@ public class ComboBoxPage extends Div {
         createExternalSetValue();
         createWithUpdateProvider();
         createWithValueChangeListener();
+        createWithUpdatableValue();
         createWithPresetValue();
         createWithButtonRenderer();
     }
@@ -125,6 +126,22 @@ public class ComboBoxPage extends Div {
         comboBox.setId("button-renderer");
 
         add(comboBox, message);
+    }
+
+    private void createWithUpdatableValue() {
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setItems("Item 1", "Item 2", "Item 3");
+        Label message = new Label();
+        NativeButton button = new NativeButton("Update value",
+                evt -> combo.setValue("Item 2"));
+
+        combo.addValueChangeListener(event -> message.setText("Value: "
+                + event.getValue() + " isFromClient: " + event.isFromClient()));
+
+        combo.setId("updatable-combo");
+        message.setId("updatable-combo-message");
+        button.setId("updatable-combo-button");
+        add(combo, message, button);
     }
 
     private void handleSelection(ComboBox<Title> titles) {

--- a/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -132,6 +132,31 @@ public class ComboBoxPageIT extends AbstractComponentIT {
         Assert.assertEquals("foo", getSelectedItemLabel(combo));
     }
 
+    @Test
+    public void changeValue_IsFromClientIsSetAccordingly() {
+        WebElement combo = findElement(By.id("updatable-combo"));
+        WebElement message = findElement(By.id("updatable-combo-message"));
+        WebElement button = findElement(By.id("updatable-combo-button"));
+
+        Assert.assertEquals("", getSelectedItemLabel(combo));
+
+        button.click();
+        Assert.assertEquals("Item 2", getSelectedItemLabel(combo));
+        Assert.assertEquals("Value: Item 2 isFromClient: false",
+                message.getText());
+
+        executeScript("arguments[0].selectedItem = arguments[0].items[0]",
+                combo);
+        Assert.assertEquals("Item 1", getSelectedItemLabel(combo));
+        Assert.assertEquals("Value: Item 1 isFromClient: true",
+                message.getText());
+
+        button.click();
+        Assert.assertEquals("Item 2", getSelectedItemLabel(combo));
+        Assert.assertEquals("Value: Item 2 isFromClient: false",
+                message.getText());
+    }
+
     private List<?> getItems(WebElement combo) {
         List<?> items = (List<?>) getCommandExecutor()
                 .executeScript("return arguments[0].items;", combo);
@@ -149,7 +174,8 @@ public class ComboBoxPageIT extends AbstractComponentIT {
     }
 
     private String getSelectedItemLabel(WebElement combo) {
-        return String.valueOf(
-                executeScript("return arguments[0].selectedItem.label", combo));
+        return String.valueOf(executeScript(
+                "return arguments[0].selectedItem ? arguments[0].selectedItem.label : \"\"",
+                combo));
     }
 }


### PR DESCRIPTION
The bug was fixed in https://github.com/vaadin/vaadin-combo-box-flow/issues/48 , this PR only adds tests for the specific issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/54)
<!-- Reviewable:end -->
