### PR TITLE
Make ComboBox.runBeforeClientResponse accept SerializableConsumer

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +40,7 @@ import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.Rendering;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -555,7 +555,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>> implements
         getElement().setProperty("itemValuePath", path == null ? "" : path);
     }
 
-    void runBeforeClientResponse(Consumer<UI> command) {
+    void runBeforeClientResponse(SerializableConsumer<UI> command) {
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> command.accept(ui)));
     }

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -32,6 +31,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.function.SerializableConsumer;
+
 
 public class ComboBoxTest {
 
@@ -50,7 +51,7 @@ public class ComboBoxTest {
         }
 
         @Override
-        void runBeforeClientResponse(Consumer<UI> command) {
+        void runBeforeClientResponse(SerializableConsumer<UI> command) {
             command.accept(new UI());
         }
     }


### PR DESCRIPTION
The input consumer must be serializable because it is captured
by a SerializableConsumer
Fixes #61

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/62)
<!-- Reviewable:end -->
