### PR TITLE
Custom values should be implicitly allowed if a value listener is assigned

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -459,6 +459,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>> implements
     @Override
     public Registration addCustomValueSetListener(
             ComponentEventListener<CustomValueSetEvent<ComboBox<T>>> listener) {
+        setAllowCustomValue(true);
         return super.addCustomValueSetListener(listener);
     }
 

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -456,6 +456,16 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>> implements
                 getElement().getPropertyRaw(SELECTED_ITEM_PROPERTY_NAME));
     }
 
+    /**
+     * Adds a listener for CustomValueSetEvent which is fired when user
+     * types in a value that don't already exist in the ComboBox.
+     *
+     * <p>As a side effect makes the ComboBox allow custom values.</p>
+     *
+     * @param listener
+     *            the listener to be notified when a new value is filled
+     * @return a {@link Registration} for removing the event listener
+     */
     @Override
     public Registration addCustomValueSetListener(
             ComponentEventListener<CustomValueSetEvent<ComboBox<T>>> listener) {

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.function.SerializableConsumer;
-
+import com.vaadin.flow.shared.Registration;
 
 public class ComboBoxTest {
 
@@ -160,7 +160,8 @@ public class ComboBoxTest {
         Assert.assertEquals(Category.CATEGORY_2, selected.get());
     }
 
-    // Ensure https://github.com/vaadin/vaadin-combo-box-flow/issues/36 does not reoccur
+    // Ensure https://github.com/vaadin/vaadin-combo-box-flow/issues/36 does not
+    // reoccur
     @Test
     public void ensureComboBoxIsFocusable() {
         Assert.assertTrue("ComboBox should be focusable",
@@ -177,10 +178,66 @@ public class ComboBoxTest {
     }
 
     @Test
-    public void shouldHaveNewItemsEnabledIfAListenerIsAdded() {
+    public void addCustomValueSetListener_customValueIsAllowed() {
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.addCustomValueSetListener(e->{});
+        comboBox.addCustomValueSetListener(e -> {
+        });
         Assert.assertTrue(comboBox.isAllowCustomValue());
+    }
+
+    @Test
+    public void addCustomValueSetListener_removeListener_customValueIsDisallowed() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        Registration registration = comboBox.addCustomValueSetListener(e -> {
+        });
+        registration.remove();
+        Assert.assertFalse(comboBox.isAllowCustomValue());
+    }
+
+    @Test
+    public void addCustomValueSetListener_disableCustomValue_customValueIsDisallowed() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        Registration registration = comboBox.addCustomValueSetListener(e -> {
+        });
+
+        comboBox.setAllowCustomValue(false);
+        Assert.assertFalse(comboBox.isAllowCustomValue());
+
+        // nothing has changed when the listener is removed
+        registration.remove();
+        Assert.assertFalse(comboBox.isAllowCustomValue());
+    }
+
+    @Test
+    public void addCustomValueSetListener_addTwoListeners_removeListenerSeveralTimes_customValueIsAllowed() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        Registration registration = comboBox.addCustomValueSetListener(e -> {
+        });
+        comboBox.addCustomValueSetListener(e -> {
+        });
+        // remove the first listener
+        registration.remove();
+        Assert.assertTrue(comboBox.isAllowCustomValue());
+
+        // removes the fist listener one more time which is no-op
+        registration.remove();
+        Assert.assertTrue(comboBox.isAllowCustomValue());
+    }
+
+    @Test
+    public void addCustomValueSetListener_addTwoListeners_removeListeners_customValueIsDisallowed() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        Registration registration1 = comboBox.addCustomValueSetListener(e -> {
+        });
+        Registration registration2 = comboBox.addCustomValueSetListener(e -> {
+        });
+        // remove the first listener
+        registration1.remove();
+        Assert.assertTrue(comboBox.isAllowCustomValue());
+
+        // removes the second listener
+        registration2.remove();
+        Assert.assertFalse(comboBox.isAllowCustomValue());
     }
 
     private void assertItem(TestComboBox comboBox, int index, String caption) {

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -176,6 +176,12 @@ public class ComboBoxTest {
         Assert.assertFalse(comboBox.isEnabled());
     }
 
+    public void shouldHaveNewItemsEnabledIfAListenerIsAdded() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.addCustomValueSetListener(e->{});
+        Assert.assertTrue(comboBox.isAllowCustomValue());
+    }
+
     private void assertItem(TestComboBox comboBox, int index, String caption) {
         String value1 = comboBox.items.get(index);
         Assert.assertEquals(caption, value1);

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -176,6 +176,7 @@ public class ComboBoxTest {
         Assert.assertFalse(comboBox.isEnabled());
     }
 
+    @Test
     public void shouldHaveNewItemsEnabledIfAListenerIsAdded() {
         ComboBox<String> comboBox = new ComboBox<>();
         comboBox.addCustomValueSetListener(e->{});


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/69)
<!-- Reviewable:end -->
