### PR TITLE
Fix IT after updated webjar

### DIFF
--- a/src/test/java/com/vaadin/flow/component/combobox/test/RefreshDataProviderIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/RefreshDataProviderIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,6 +55,11 @@ public class RefreshDataProviderIT extends AbstractComponentIT {
 
     private List<String> getItems() {
         findElement(By.tagName("vaadin-combo-box")).sendKeys(Keys.ARROW_DOWN);
+
+        if (!isElementPresent(By.tagName("vaadin-combo-box-overlay"))) {
+            return new ArrayList<String>();
+        }
+
         WebElement overlay = findElement(
                 By.tagName("vaadin-combo-box-overlay"));
         WebElement content = getInShadowRoot(overlay, By.id("content"));


### PR DESCRIPTION
After web component update, the combo-box overlay is not attached if
there are no items to display. This caused one test to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/113)
<!-- Reviewable:end -->
