### PR TITLE
Remove value-property in component value clear.

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -528,6 +528,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void cleanValueAndSelection() {
+        /* in certain use case, leaving the value property
+           will enforce value refresh with empty value, even though
+           actual value was set. */
         getElement().removeProperty(VALUE_PROPERTY_NAME);
         getElement().setPropertyJson(SELECTED_ITEM_PROPERTY_NAME,
                 Json.createNull());

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -528,7 +528,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void cleanValueAndSelection() {
-        getElement().setProperty(VALUE_PROPERTY_NAME, "");
+        getElement().removeProperty(VALUE_PROPERTY_NAME);
         getElement().setPropertyJson(SELECTED_ITEM_PROPERTY_NAME,
                 Json.createNull());
     }


### PR DESCRIPTION
Fixes #118 .

When using binder with combobox, setting value, clearing it and
resetting value combobox ends up empty, for value is refreshed as
empty string (set in value clear) after the correct value (set bean
in binder) was first set.

Refresh occurs in client-side property flushing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/119)
<!-- Reviewable:end -->
