### PR TITLE
Remove value-property in component value clear (#119)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -527,7 +527,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void cleanValueAndSelection() {
-        getElement().setProperty(VALUE_PROPERTY_NAME, "");
+        /* in certain use case, leaving the value property
+           will enforce value refresh with empty value, even though
+           actual value was set. */
+        getElement().removeProperty(VALUE_PROPERTY_NAME);
         getElement().setPropertyJson(SELECTED_ITEM_PROPERTY_NAME,
                 Json.createNull());
     }


### PR DESCRIPTION
* Fixes issue https://github.com/vaadin/vaadin-combo-box-flow/issues/118 .

When using binder with combobox, setting value, clearing it and
resetting value combobox ends up empty, for value is refreshed as
empty string (set in value clear) after the correct value (set bean
in binder) was first set.

Refresh occurs in client-side property flushing.

* Comments fixed.

Creating a regression test for this fix is complicated. Only scenario
that have shown this issue, is within bakery-application user editing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/120)
<!-- Reviewable:end -->
