### PR TITLE
Using DataProvider::getId in setValue to find the item (#117)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -517,13 +518,16 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             }
             return;
         }
-        int updatedIndex = itemsFromDataProvider.indexOf(value);
-        if (updatedIndex < 0) {
+        Optional<T> item = itemsFromDataProvider.stream()
+                .filter(object -> Objects.equals(dataProvider.getId(value)
+                        , dataProvider.getId(object)))
+                .findFirst();
+        if (!item.isPresent()) {
             throw new IllegalArgumentException(
                     "The provided value is not part of ComboBox: " + value);
         }
         getElement().setPropertyJson(SELECTED_ITEM_PROPERTY_NAME,
-                generateJson(itemsFromDataProvider.get(updatedIndex)));
+                generateJson(item.get()));
     }
 
     private void cleanValueAndSelection() {

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.combobox;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,13 +29,12 @@ import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.combobox.bean.TestItem;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
-
-import static org.junit.Assert.assertEquals;
 
 public class ComboBoxTest {
 
@@ -245,6 +246,35 @@ public class ComboBoxTest {
         // removes the second listener
         registration2.remove();
         Assert.assertFalse(comboBox.isAllowCustomValue());
+    }
+
+    @Test
+    public void setValue_nonMatchingId_IllegalArgumentException() {
+        List<TestItem> list = Arrays.asList(new TestItem(1, "a", "First"),
+                new TestItem(2, "b", "Second"), new TestItem(3, "c", "Third"));
+
+        expectIllegalArgumentException(
+                "The provided value is not part of ComboBox:");
+        ComboBox comboBox = new ComboBox();
+        comboBox.setDataProvider(new ListDataProvider<TestItem>(list) {
+            @Override
+            public Object getId(TestItem item) {
+                return item.getId();
+            }
+        });
+        comboBox.setValue(new TestItem(0, "b", ""));
+    }
+
+    @Test
+    public void setValue_nonExistingObject_IllegalArgumentException() {
+        List<TestItem> list = Arrays.asList(new TestItem(1, "a", "First"),
+                new TestItem(2, "b", "Second"), new TestItem(3, "c", "Third"));
+
+        expectIllegalArgumentException(
+                "The provided value is not part of ComboBox:");
+        ComboBox comboBox = new ComboBox();
+        comboBox.setItems(list);
+        comboBox.setValue(new TestItem(2, "bbb", ""));
     }
 
     private void assertItem(TestComboBox comboBox, int index, String caption) {

--- a/src/test/java/com/vaadin/flow/component/combobox/bean/TestItem.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/bean/TestItem.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *
+ */
+
+package com.vaadin.flow.component.combobox.bean;
+
+import java.util.Objects;
+
+public class TestItem {
+    private int id;
+    private String name;
+    private String comments;
+
+    public TestItem(int id) {
+        this.id = id;
+    }
+
+    public TestItem(int id, String name, String comments) {
+        this.id = id;
+        this.name = name;
+        this.comments = comments;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name + ", " + comments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestItem testItem = (TestItem) o;
+        return Objects.equals(name, testItem.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}
+

--- a/src/test/java/com/vaadin/flow/component/combobox/test/DataProviderIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/DataProviderIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("data-provider")
+public class DataProviderIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+    }
+
+    @Test
+    public void setValue_ProviderHasGetIdAndValueIdExists_selectionTextShouldBeSet() {
+        open();
+        findElement(By.id(DataProviderPage.SET_VALUE_USING_GET_ID_BUTTON_ID))
+                .click();
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(DataProviderPage.COMBO_BOX_WITH_GET_ID_ID);
+        Assert.assertEquals(
+                "ComboBox::setValue must use DataProvider::getId to find the item.",
+                "b, Second", comboBox.getSelectedText());
+    }
+
+    @Test
+    public void setValue_ValueReferenceExists_selectionTextShouldBeSet() {
+        open();
+        findElement(By.id(DataProviderPage.SET_VALUE_USING_REFERENCE_BUTTON_ID))
+                .click();
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(DataProviderPage.COMBO_BOX_WITHOUT_GET_ID_ID);
+        Assert.assertEquals(
+                "ComboBox::setValue must use object reference to find the item.",
+                "b, Second", comboBox.getSelectedText());
+    }
+
+    @Test
+    public void setValue_ValueEqualToAnExistingItem_selectionTextShouldBeSet() {
+        open();
+        findElement(By.id(DataProviderPage.SET_VALUE_USING_EQUALS_BUTTON_ID))
+                .click();
+        ComboBoxElement comboBox = $(ComboBoxElement.class)
+                .id(DataProviderPage.COMBO_BOX_WITHOUT_GET_ID_ID);
+        Assert.assertEquals(
+                "ComboBox::setValue must use Object::equals to find the item.",
+                "c, Third", comboBox.getSelectedText());
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/DataProviderPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/DataProviderPage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.bean.TestItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Route("data-provider")
+public class DataProviderPage extends Div {
+    static final String COMBO_BOX_WITH_GET_ID_ID = "comboBoxWithGetId";
+    static final String COMBO_BOX_WITHOUT_GET_ID_ID = "comboBoxWithoutGetId";
+    static final String SET_VALUE_USING_GET_ID_BUTTON_ID = "setValueUsingGetIdButton";
+    static final String SET_VALUE_USING_REFERENCE_BUTTON_ID = "setValueUsingReferenceButton";
+    static final String SET_VALUE_USING_EQUALS_BUTTON_ID = "setValueUsingEqualsButton";
+
+    public DataProviderPage() {
+        List<TestItem> list = Arrays.asList(new TestItem(1, "a", "First"),
+                new TestItem(2, "b", "Second"), new TestItem(3, "c", "Third"));
+
+        ComboBox<TestItem> comboBoxWithGetId = new ComboBox<>();
+        comboBoxWithGetId.setId(COMBO_BOX_WITH_GET_ID_ID);
+        comboBoxWithGetId.setDataProvider(new ListDataProvider<TestItem>(list) {
+            @Override
+            public Object getId(TestItem item) {
+                return item.getId();
+            }
+        });
+        add(comboBoxWithGetId);
+
+        ComboBox<TestItem> comboBoxWithoutGetId = new ComboBox<>();
+        comboBoxWithoutGetId.setId(COMBO_BOX_WITHOUT_GET_ID_ID);
+        comboBoxWithoutGetId.setItems(list);
+        add(comboBoxWithoutGetId);
+
+        NativeButton setValueUsingIdButton = new NativeButton(
+                "Set Value Using Id",
+                event -> comboBoxWithGetId.setValue(new TestItem(2)));
+        setValueUsingIdButton.setId(SET_VALUE_USING_GET_ID_BUTTON_ID);
+        add(setValueUsingIdButton);
+
+        NativeButton setValueUsingReferenceButton = new NativeButton(
+                "Set Value Using Reference",
+                event -> comboBoxWithoutGetId.setValue(list.get(1)));
+        setValueUsingReferenceButton.setId(SET_VALUE_USING_REFERENCE_BUTTON_ID);
+        add(setValueUsingReferenceButton);
+
+        NativeButton setValueUsingEqualsButton = new NativeButton(
+                "Set Value Using Equals", event -> comboBoxWithoutGetId
+                        .setValue(new TestItem(4, "c", "")));
+        setValueUsingEqualsButton.setId(SET_VALUE_USING_EQUALS_BUTTON_ID);
+        add(setValueUsingEqualsButton);
+    }
+}


### PR DESCRIPTION
* Using DataProvider::getId in setValue to find the item
Fixes #111

* Adding two unit tests for exceptional cases of setValue
and renaming IT method names based on Flow naming convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/121)
<!-- Reviewable:end -->
