### PR TITLE
Clear selectedItem on setValue(null)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -312,6 +312,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             value = keyMapper.get(keyMapper.key(value));
         }
 
+        if (value == null) {
+            getElement().setProperty("selectedItem", null);
+            return;
+        }
+
         // This ensures that the selection works even with lazy loading when the
         // item is not yet loaded
         JsonObject json = Json.createObject();

--- a/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/ComboBoxTest.java
@@ -256,6 +256,17 @@ public class ComboBoxTest {
         comboBox.setPageSize(0);
     }
 
+    @Test
+    public void setValueNull_selectedItemNull() {
+        ComboBox<String> comboBox = new ComboBox<>("1", "2");
+        comboBox.setValue("1");
+        comboBox.setValue(null);
+        Assert.assertNull(
+                "The selectedItem property must be null when there's no value. "
+                        + "Otherwise the 'clear value'-button will be shown.",
+                comboBox.getSelectedItemJsonObject());
+    }
+
     private void assertItem(TestComboBox comboBox, int index, String caption) {
         String value1 = comboBox.items.get(index);
         Assert.assertEquals(caption, value1);


### PR DESCRIPTION
It used to generate a json-object even for null with just an empty
label. This caused the "clear value"-button with "x" to be shown even
when the value was null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/141)
<!-- Reviewable:end -->
