### PR TITLE
Use filtering configured in DataProvider

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -402,9 +402,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @Override
     public void setDataProvider(DataProvider<T, String> dataProvider) {
-        if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
-            userProvidedFilter = UserProvidedFilter.YES;
-        }
         setDataProvider(dataProvider, SerializableFunction.identity());
     }
 

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -403,7 +403,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     @Override
     public void setDataProvider(DataProvider<T, String> dataProvider) {
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
-            userProvidedFilter = UserProvidedFilter.NO;
+            userProvidedFilter = UserProvidedFilter.YES;
         }
         setDataProvider(dataProvider, SerializableFunction.identity());
     }

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -530,8 +530,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         Objects.requireNonNull(listDataProvider,
                 "List data provider cannot be null");
 
-        // Must do getItemLabelGenerator() for each operation since it might
-        // not be the same as when this method was invoked
         setDataProvider(listDataProvider,
                 filterText -> item -> itemFilter.test(item, filterText));
     }

--- a/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/FilteringIT.java
@@ -136,6 +136,20 @@ public class FilteringIT extends AbstractComboBoxIT {
         assertRendered("Item 0");
     }
 
+    @Test
+    public void configureFilterInDataProvider_setDataProvider_serverSideFiltering() {
+        box = $(ComboBoxElement.class).id("filterable-data-provider");
+        box.openPopup();
+        assertRendered("foo");
+        List<String> filteredItems = setFilterAndGetImmediateResults("f");
+        Assert.assertEquals("Expected server-side filtering, so there "
+                + "should be no filtered items until server has responded.", 0,
+                filteredItems.size());
+
+        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
+        assertRendered("filtered");
+    }
+
     private void assertClientSideFilter(boolean clientSide) {
         assertClientSideFilter(clientSide, "3", 13);
     }

--- a/src/test/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/FilteringPage.java
@@ -16,11 +16,13 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.combobox.ComboBox.ItemFilter;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.router.Route;
@@ -72,6 +74,29 @@ public class FilteringPage extends Div {
         pageSizeBox.setLabel("Page size 60");
         pageSizeBox.setId("page-size-60");
         add(new Div(), pageSizeBox);
+
+        ComboBox<String> comboBoxWithFilterableDataProvider = new ComboBox<>();
+        comboBoxWithFilterableDataProvider.setId("filterable-data-provider");
+        comboBoxWithFilterableDataProvider
+                .setLabel("Filter configured in the data provider");
+        CallbackDataProvider<String, String> dataProviderWithFiltering = DataProvider
+                .fromFilteringCallbacks(query -> {
+                    return IntStream
+                            .range(query.getOffset(),
+                                    query.getOffset() + query.getLimit())
+                            .mapToObj(i -> {
+                                if (query.getFilter().isPresent()) {
+                                    return "filtered";
+                                } else {
+                                    return "foo";
+                                }
+                            });
+                }, query -> {
+                    return 1;
+                });
+        comboBoxWithFilterableDataProvider
+                .setDataProvider(dataProviderWithFiltering);
+        add(new Div(), comboBoxWithFilterableDataProvider);
     }
 
 }


### PR DESCRIPTION
When using the overload that takes just a DataProvider, use server-side
filtering so that a filter defined in the DataProvider is used. There's
still an overload with ListDataProvider which allows client-side
filtering.

Fixes #140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/143)
<!-- Reviewable:end -->
