### PR TITLE
Improve javadocs and demo based on DX tests

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -353,6 +353,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      * filter text is a substring of the label displayed for that item, which
      * you can configure with
      * {@link #setItemLabelGenerator(ItemLabelGenerator)}.
+     * <p>
+     * Filtering will be handled in the client-side if the size of the data set
+     * is less than the page size. To force client-side filtering with a larger
+     * data set (at the cost of increased network traffic), you can increase the
+     * page size with {@link #setPageSize(int)}.
      */
     @Override
     public void setItems(Collection<T> items) {
@@ -467,6 +472,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      * filter text is a substring of the label displayed for that item, which
      * you can configure with
      * {@link #setItemLabelGenerator(ItemLabelGenerator)}.
+     * <p>
+     * Filtering will be handled in the client-side if the size of the data set
+     * is less than the page size. To force client-side filtering with a larger
+     * data set (at the cost of increased network traffic), you can increase the
+     * page size with {@link #setPageSize(int)}.
      *
      * @param listDataProvider
      *            the list data provider to use, not <code>null</code>

--- a/src/test/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/demo/ComboBoxView.java
@@ -228,7 +228,7 @@ public class ComboBoxView extends DemoView {
          * Providing a custom item filter allows filtering based on all of
          * the rendered properties:
          */
-        ItemFilter<Song> filter = (song, filterString) -> 
+        ItemFilter<Song> filter = (song, filterString) ->
                 song.getName().toLowerCase()
                     .contains(filterString.toLowerCase())
                 || song.getArtist().toLowerCase()
@@ -272,7 +272,18 @@ public class ComboBoxView extends DemoView {
         ComboBox<Song> comboBox = new ComboBox<>();
 
         List<Song> listOfSongs = createListOfSongs();
-        comboBox.setItems(listOfSongs);
+
+        /*
+         * Providing a custom item filter allows filtering based on all of
+         * the rendered properties:
+         */
+        ItemFilter<Song> filter = (song, filterString) ->
+                song.getName().toLowerCase()
+                    .contains(filterString.toLowerCase())
+                || song.getArtist().toLowerCase()
+                    .contains(filterString.toLowerCase());
+
+        comboBox.setItems(filter, listOfSongs);
 
         comboBox.setItemLabelGenerator(Song::getName);
 

--- a/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
@@ -169,6 +169,24 @@ public class ComboBoxIT extends TabbedComponentDemoTest {
     }
 
     @Test
+    public void componentBoxCustomFiltering_filterableByArtist() {
+        openTabAndCheckForErrors("using-components");
+        ComboBoxElementUpdated comboBox = $(ComboBoxElementUpdated.class)
+                .id("component-selection-box");
+        comboBox.openPopup();
+        comboBox.setFilter("ha");
+
+        waitUntil(driver -> ((List<Map<String, ?>>) executeScript(
+                "return arguments[0].filteredItems", comboBox)).size() == 2);
+
+        List<Map<String, ?>> items = (List<Map<String, ?>>) executeScript(
+                "return arguments[0].filteredItems", comboBox);
+
+        Assert.assertEquals("A V Club Disagrees", items.get(0).get("label"));
+        Assert.assertEquals("Sculpted", items.get(1).get("label"));
+    }
+
+    @Test
     public void openComponentBox() {
         openTabAndCheckForErrors("using-components");
 


### PR DESCRIPTION
Added information about the client-side filtering and page size to the
first place where users tried to find it: in setItems().

Added demo about using ItemFilter also to ComponentRenderer demo,
because it is hard to create a lambda with two parameters and it's best
to see an example. This increases the chance of finding such example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/144)
<!-- Reviewable:end -->
