### PR TITLE
Fix loading indicator when server returns zero items

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -74,6 +74,13 @@ window.Vaadin.Flow.comboBoxConnector = {
         throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
       }
 
+      if (index === 0 && items.length === 0 && pageCallbacks[0]) {
+        // Makes sure that the dataProvider callback is called even when server
+        // returns empty data set (no items match the filter).
+        cache[0] = [];
+        return;
+      }
+
       const firstPageToSet = index / comboBox.pageSize;
       const updatedPageCount = Math.ceil(items.length / comboBox.pageSize);
 

--- a/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -331,6 +331,19 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void filterMatchesNoItems_loadingStateResolved() {
+        // Otherwise the spinner is not cleared and it looks like the web
+        // component is still waiting for more data.
+        stringBox.openPopup();
+        stringBox.setFilter("foo");
+        waitUntil(driver -> !stringBox.getPropertyBoolean("loading"));
+        assertLoadedItemsCount(
+                "Expected no items to be loaded after setting "
+                        + "a filter which doesn't match any item",
+                0, stringBox);
+    }
+
+    @Test
     public void callbackDataprovider_pagesLoadedLazily() {
         callbackBox.openPopup();
         assertLoadedItemsCount(


### PR DESCRIPTION
When no items match the filter, the dataProvider callback was left
hanging and the spinner was never removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/153)
<!-- Reviewable:end -->
