### PR TITLE
Fix: value is not updated when null in ComboBox

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -324,6 +324,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         if (value == null) {
             getElement().setProperty("selectedItem", null);
+            getElement().setProperty("value", "");
+            getElement().setProperty("_inputElementValue", "");
             return;
         }
 

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -459,13 +459,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
             userProvidedFilter = UserProvidedFilter.YES;
         }
-        
-        if(getElement().getProperty("$connector") == null) {
-        	Element e = getElement();
-	        while(e.getParent() != null)
-	        	e = e.getParent();
-	        e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
-        }
 
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -459,6 +459,13 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
             userProvidedFilter = UserProvidedFilter.YES;
         }
+        
+        if(getElement().getProperty("$connector") == null) {
+        	Element e = getElement();
+	        while(e.getParent() != null)
+	        	e = e.getParent();
+	        e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
+        }
 
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,


### PR DESCRIPTION
This should fix input element value not being empty when setting value to null. This is because the JS selectedItemChanged method does not update value unless customInput is disabled due to selectedItem being set to null each time the input no longer matches a dropdown option.

This should fix #180 but does not address another issue that caused numbers to be displayed. I will open an issue for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/186)
<!-- Reviewable:end -->
