### PR TITLE
 Initialize $connector if values were not set in ComboBox element prior to page load.

### DIFF
--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -324,6 +324,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         if (value == null) {
             getElement().setProperty("selectedItem", null);
+            getElement().setProperty("value", "");
+            getElement().setProperty("_inputElementValue", "");
             return;
         }
 

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -466,10 +466,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             userProvidedFilter = UserProvidedFilter.YES;
         }
         
-        if(getElement().getProperty("$connector") == null) {
-            UI.getCurrent().getPage().executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
-        }
-
+        runBeforeClientResponse(ui -> ui.getPage().executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement()));
+        
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,
                     arrayUpdater, data -> getElement()

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -461,10 +461,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         }
         
         if(getElement().getProperty("$connector") == null) {
-        	Element e = getElement();
-	        while(e.getParent() != null)
-	        	e = e.getParent();
-	        e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
+            Element e = getElement();
+            while(e.getParent() != null)
+                e = e.getParent();
+            e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
         }
 
         if (dataCommunicator == null) {

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -459,6 +459,13 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
             userProvidedFilter = UserProvidedFilter.YES;
         }
+        
+        if(getElement().getProperty("$connector") == null) {
+        	Element e = getElement();
+	        while(e.getParent() != null)
+	        	e = e.getParent();
+	        e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
+        }
 
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -461,10 +461,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         }
         
         if(getElement().getProperty("$connector") == null) {
-            Element e = getElement();
-            while(e.getParent() != null)
-                e = e.getParent();
-            e.executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
+            UI.getCurrent().getPage().executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement());
         }
 
         if (dataCommunicator == null) {


### PR DESCRIPTION
Initializes the $connector property on ComboBox's element if this was not done prior to changing DataCommunicator by calling the comboBoxConnector.initLazy() function.

Should fix #169

The first commit is in pull #186 and fixes #180 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/188)
<!-- Reviewable:end -->
