### PR TITLE
2.0.3 cherry picks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
                 <configuration>
                     <webApp>
                         <resourceBases>

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -333,6 +333,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         json.put("key", keyMapper.key(value));
         dataGenerator.generateData(value, json);
         setSelectedItem(json);
+
+        // Workaround for property not updating in certain scenario
+        // https://github.com/vaadin/flow/issues/4862
+        runBeforeClientResponse(
+                ui -> ui.getPage().executeJavaScript("$0.value=$1",
+                        getElement(), getElement().getProperty("value")));
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -324,6 +324,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         if (value == null) {
             getElement().setProperty("selectedItem", null);
+            getElement().setProperty("value", "");
+            getElement().setProperty("_inputElementValue", "");
             return;
         }
 

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -465,9 +465,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
             userProvidedFilter = UserProvidedFilter.YES;
         }
-        
+
         runBeforeClientResponse(ui -> ui.getPage().executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement()));
-        
+
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,
                     arrayUpdater, data -> getElement()

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -465,7 +465,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (userProvidedFilter == UserProvidedFilter.UNDECIDED) {
             userProvidedFilter = UserProvidedFilter.YES;
         }
-
+        
+        runBeforeClientResponse(ui -> ui.getPage().executeJavaScript("window.Vaadin.Flow.comboBoxConnector.initLazy($0);", getElement()));
+        
         if (dataCommunicator == null) {
             dataCommunicator = new DataCommunicator<>(dataGenerator,
                     arrayUpdater, data -> getElement()

--- a/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -49,6 +49,7 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.shared.Registration;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
@@ -196,7 +197,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private boolean renderScheduled;
 
     // Filter set by the client when requesting data. It's sent back to client
-    // together with the response so client may know for what filter data is provided.
+    // together with the response so client may know for what filter data is
+    // provided.
     private String lastFilter;
 
     private DataCommunicator<T> dataCommunicator;
@@ -876,6 +878,13 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         customValueListenersCount++;
         Registration registration = super.addCustomValueSetListener(listener);
         return new CustomValueRegistration(registration);
+    }
+
+    @Override
+    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+        super.setRequiredIndicatorVisible(requiredIndicatorVisible);
+        getElement().callFunction("$connector.enableClientValidation",
+                !requiredIndicatorVisible);
     }
 
     CompositeDataGenerator<T> getDataGenerator() {

--- a/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -162,6 +162,61 @@ window.Vaadin.Flow.comboBoxConnector = {
       // Let server know we're done
       comboBox.$server.confirmUpdate(id);
     }
+    
+    comboBox.$connector.enableClientValidation = function( enable ){
+        let input = comboBox.$["input"];
+        if (input){
+            if ( enable){
+                enableClientValidation(comboBox);
+                enableTextFieldClientValidation(input);
+            }
+            else {
+                disableClientValidation(comboBox);
+                disableTextFieldClientValidation(input,comboBox );
+            }
+        }
+        else {
+            setTimeout( function(){ 
+                comboBox.$connector.enableClientValidation(enable); 
+                }, 10);
+        }
+    }
+    
+    const disableClientValidation =  function (combo){
+        if ( typeof combo.$checkValidity == 'undefined'){
+            combo.$checkValidity = combo.checkValidity;
+            combo.checkValidity = function() { return true; };
+        }
+        if ( typeof combo.$validate == 'undefined'){
+            combo.$validate = combo.validate;
+            combo.validate = function() { return true; };
+        }
+    }
+    
+    const disableTextFieldClientValidation =  function (field, comboBox){
+        if ( typeof field.$checkValidity == 'undefined'){
+            field.$checkValidity = field.checkValidity;
+            field.checkValidity = function() { return !comboBox.invalid; };
+        }
+    }
+    
+    const enableTextFieldClientValidation = function (field){
+        if ( field.$checkValidity ){
+            field.checkValidity = field.$checkValidity;
+            delete field.$checkValidity;
+        }
+     }
+    
+    const enableClientValidation = function (combo){
+        if ( combo.$checkValidity ){
+            combo.checkValidity = combo.$checkValidity;
+            delete combo.$checkValidity;
+        }
+          if ( combo.$validate ){
+            combo.validate = combo.$validate;
+            delete combo.$validate;
+        }
+     }
 
     const commitPage = function (page, callback) {
       let data = cache[page];

--- a/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -55,8 +55,7 @@ window.Vaadin.Flow.comboBoxConnector = {
                 comboBox.$server.resetDataCommunicator();
               }
             });
-        }
-        else {
+        } else {
           comboBox.$server.setRequestedRange(0, upperLimit, params.filter);
         }
 
@@ -69,7 +68,11 @@ window.Vaadin.Flow.comboBoxConnector = {
       return comboBox._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
     }
 
-    comboBox.$connector.set = function (index, items) {
+    comboBox.$connector.set = function (index, items, filter) {
+      if (filter != lastFilter) {
+        return;
+      }
+
       if (index % comboBox.pageSize != 0) {
         throw 'Got new data to index ' + index + ' which is not aligned with the page size of ' + comboBox.pageSize;
       }
@@ -117,7 +120,12 @@ window.Vaadin.Flow.comboBoxConnector = {
       comboBox.clearCache();
     };
 
-    comboBox.$connector.confirm = function (id) {
+    comboBox.$connector.confirm = function (id, filter) {
+
+      if (filter != lastFilter) {
+        return;
+      }
+
       // We're done applying changes from this batch, resolve outstanding
       // callbacks
       let outstandingRequests = Object.getOwnPropertyNames(pageCallbacks);

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -21,13 +21,15 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.testbench.TestBenchElement;
-import elemental.json.JsonObject;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.testbench.TestBenchElement;
+
+import elemental.json.JsonObject;
 
 @Ignore
 public class AbstractComboBoxIT extends AbstractComponentIT {

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -16,17 +16,18 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import org.junit.Assert;
-import org.junit.Ignore;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.testbench.TestBenchElement;
-
 import elemental.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.openqa.selenium.WebElement;
 
 @Ignore
 public class AbstractComboBoxIT extends AbstractComponentIT {
@@ -130,4 +131,47 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
         $("button").id(id).click();
     }
 
+    protected List<?> getItems(WebElement combo) {
+        executeScript("arguments[0].opened=true", combo);
+        List<?> items = (List<?>) getCommandExecutor()
+                .executeScript("return arguments[0].filteredItems;", combo);
+        executeScript("arguments[0].opened=false", combo);
+        return items;
+    }
+
+    protected void assertItem(List<?> items, int index, String caption) {
+        Map<?, ?> map = (Map<?, ?>) items.get(index);
+        Assert.assertEquals(caption, map.get("label"));
+    }
+
+    protected String getItemLabel(List<?> items, int index) {
+        Map<?, ?> map = (Map<?, ?>) items.get(index);
+        return (String) map.get("label");
+    }
+
+    protected String getSelectedItemLabel(WebElement combo) {
+        return String.valueOf(executeScript(
+                "return arguments[0].selectedItem ? arguments[0].selectedItem.label : \"\"",
+                combo));
+    }
+
+    /**
+     * Wait for the items of the specified combobox to fulfill the specified
+     * condition.
+     * 
+     * @param combo
+     *            The combobox element.
+     * @param condition
+     *            The condition to wait for.
+     */
+    protected void waitForItems(WebElement combo,
+            Function<List<?>, Boolean> condition) {
+
+        waitUntil(driver -> {
+            List comboItems = (List<?>) getCommandExecutor()
+                    .executeScript("return arguments[0].filteredItems;", combo);
+
+            return condition.apply(comboItems);
+        });
+    }
 }

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -158,7 +158,7 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
     /**
      * Wait for the items of the specified combobox to fulfill the specified
      * condition.
-     * 
+     *
      * @param combo
      *            The combobox element.
      * @param condition

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+@TestPath("auto-focus-filter")
+public class AutoFocusFilterIT extends AbstractComboBoxIT {
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+    }
+
+    @Test
+    public void filter_itemsShouldBeThere() {
+        ComboBoxElement comboBox = $(ComboBoxElementUpdated.class).first();
+
+        comboBox.sendKeys("2");
+
+        waitForItems(comboBox,
+                items -> items.size() == 2
+                        && "Option 2".equals(getItemLabel(items, 0))
+                        && "Another Option 2".equals(getItemLabel(items, 1)));
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterIT.java
@@ -24,6 +24,7 @@ import org.openqa.selenium.By;
 
 @TestPath("auto-focus-filter")
 public class AutoFocusFilterIT extends AbstractComboBoxIT {
+
     @Before
     public void init() {
         open();

--- a/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/AutoFocusFilterPage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Route("auto-focus-filter")
+public class AutoFocusFilterPage extends Div {
+
+    public AutoFocusFilterPage() {
+        List<String> data = Arrays.asList("Option 2", "Option 3", "Option 4",
+                "Option 5", "Another Option 2");
+
+        ComboBox<String> comboBox = new ComboBox<>("Choose option");
+        comboBox.setDataProvider((ComboBox.FetchItemsCallback<String>) (filter,
+                offset, limit) -> {
+            if (filter.isEmpty())
+                return Stream.of("");
+            return data.stream().filter(s -> s.contains(filter)).skip(offset)
+                    .limit(limit);
+        }, (filter) -> {
+            if (filter.isEmpty())
+                return 1;
+            return (int) data.stream().filter(s -> s.contains(filter)).count();
+        });
+
+        comboBox.setAutofocus(true);
+        this.add(comboBox);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+@TestPath("clientside-filter")
+public class ClientSideFilterIT extends AbstractComboBoxIT {
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+    }
+
+    @Test
+    public void filter_itemsShouldBeThere() {
+        // First combobox.
+        ComboBoxElement comboBox = $(ComboBoxElementUpdated.class).first();
+
+        comboBox.sendKeys("2");
+
+        waitForItems(comboBox, items -> items.size() == 1
+                && "Option 2".equals(getItemLabel(items, 0)));
+
+        comboBox.sendKeys(Keys.BACK_SPACE);
+
+        waitForItems(comboBox, items -> items.size() == 4);
+
+        comboBox.sendKeys("3");
+
+        waitForItems(comboBox, items -> items.size() == 1
+                && "Option 3".equals(getItemLabel(items, 0)));
+
+        // Second combobox.
+        comboBox = $(ComboBoxElementUpdated.class).get(1);
+
+        comboBox.sendKeys("mo");
+
+        waitForItems(comboBox,
+                items -> items.size() == 1
+                        && "Mozilla Firefox".equals(getItemLabel(items, 0)));
+
+        comboBox.closePopup();
+        comboBox.openPopup();
+
+        waitForItems(comboBox,
+                items -> items.size() == 5
+                        && "Google Chrome".equals(getItemLabel(items, 0))
+                        && "Mozilla Firefox".equals(getItemLabel(items, 1))
+                        && "Opera".equals(getItemLabel(items, 2))
+                        && "Apple Safari".equals(getItemLabel(items, 3))
+                        && "Microsoft Edge".equals(getItemLabel(items, 4)));
+
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ClientSideFilterPage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.router.Route;
+
+@Route("clientside-filter")
+public class ClientSideFilterPage extends Div {
+
+    public ClientSideFilterPage() {
+        ComboBox<String> cb = new ComboBox<>("Choose option", "Option 2",
+                "Option 3", "Option 4", "Option 5");
+        this.add(cb);
+        cb.focus();
+
+        this.add(new Hr());
+
+        ComboBox<String> testBox = new ComboBox<>("Browsers");
+        testBox.setItems("Google Chrome", "Mozilla Firefox", "Opera",
+                "Apple Safari", "Microsoft Edge");
+        this.add(testBox);
+
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -15,24 +15,20 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import static org.junit.Assert.assertFalse;
-
 import java.util.List;
-import java.util.Map;
 
+import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
+import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
-import com.vaadin.testbench.TestBenchElement;
+import static org.junit.Assert.assertFalse;
 
 @TestPath("combo-box-test")
-public class ComboBoxPageIT extends AbstractComponentIT {
+public class ComboBoxPageIT extends AbstractComboBoxIT {
 
     @Before
     public void init() {
@@ -53,13 +49,13 @@ public class ComboBoxPageIT extends AbstractComponentIT {
         // update data provider
         findElement(By.id("update-provider")).click();
 
-        waitUntil(driver -> "baz".equals(getItem(getItems(combo), 0)));
+        waitUntil(driver -> "baz".equals(getItemLabel(getItems(combo), 0)));
         assertItem(getItems(combo), 1, "foobar");
 
         // update item caption generator
         findElement(By.id("update-caption-gen")).click();
 
-        waitUntil(driver -> "3".equals(getItem(getItems(combo), 0)));
+        waitUntil(driver -> "3".equals(getItemLabel(getItems(combo), 0)));
         assertItem(getItems(combo), 1, "6");
     }
 
@@ -133,7 +129,7 @@ public class ComboBoxPageIT extends AbstractComponentIT {
         WebElement combo = findElement(By.id("combo"));
 
         findElement(By.id("update-provider")).click();
-        waitUntil(driver -> "baz".equals(getItem(getItems(combo), 0)));
+        waitUntil(driver -> "baz".equals(getItemLabel(getItems(combo), 0)));
 
         findElement(By.id("update-value")).click();
         String value = getSelectedItemLabel(combo);
@@ -184,33 +180,4 @@ public class ComboBoxPageIT extends AbstractComponentIT {
                 message.getText());
     }
 
-    private TestBenchElement getItemFromBox(int index) {
-        return $(TestBenchElement.class).id("overlay").$(TestBenchElement.class)
-                .id("content").$(TestBenchElement.class).id("selector")
-                .$("vaadin-combo-box-item").get(index);
-    }
-
-    private List<?> getItems(WebElement combo) {
-        executeScript("arguments[0].opened=true", combo);
-        List<?> items = (List<?>) getCommandExecutor()
-                .executeScript("return arguments[0].filteredItems;", combo);
-        executeScript("arguments[0].opened=false", combo);
-        return items;
-    }
-
-    private void assertItem(List<?> items, int index, String caption) {
-        Map<?, ?> map = (Map<?, ?>) items.get(index);
-        Assert.assertEquals(caption, map.get("label"));
-    }
-
-    private Object getItem(List<?> items, int index) {
-        Map<?, ?> map = (Map<?, ?>) items.get(index);
-        return map.get("label");
-    }
-
-    private String getSelectedItemLabel(WebElement combo) {
-        return String.valueOf(executeScript(
-                "return arguments[0].selectedItem ? arguments[0].selectedItem.label : \"\"",
-                combo));
-    }
 }

--- a/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.test.template.ComboBoxInATemplate;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H4;
 import com.vaadin.flow.component.html.Label;

--- a/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangeIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangeIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+import java.util.List;
+import java.util.Map;
+
+@TestPath("null-value-change")
+public class NullValueChangeIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+    }
+
+    @Test
+    public void setValue_selectionTextShouldBeEmpty() {
+        open();
+        ComboBoxElement comboBox = $(ComboBoxElementUpdated.class).first();
+
+        comboBox.openPopup();
+
+        List<Map<String, ?>> items = (List<Map<String, ?>>) executeScript(
+                "return arguments[0].filteredItems", comboBox);
+
+        executeScript(
+                "arguments[0].selectedItem = arguments[0].filteredItems[1]",
+                comboBox);
+
+        Assert.assertEquals(
+                "_inputElementValue must be empty.",
+                "", comboBox.getAttribute("_inputElementValue"));
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangePage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/NullValueChangePage.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("null-value-change")
+public class NullValueChangePage extends Div {
+
+    public static class Person implements Serializable {
+        private String name;
+        public Person(String firstName) {
+            this.name = firstName;
+        }
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    public NullValueChangePage() {
+        Person jorma = new Person("Jorma");
+        Person kalle = new Person("Kalle");
+        List<Person> list = Arrays.asList(jorma, kalle);
+
+        ComboBox<Person> cb = new ComboBox<>();
+        cb.setItems(list);
+        cb.addValueChangeListener(e -> {
+            e.getSource().setValue(null);
+        });
+
+        cb.setAllowCustomValue(true);
+        add(cb); // MainView extends VerticalLayout
+
+    }
+}
+

--- a/src/test/java/com/vaadin/flow/component/combobox/test/RequiredComboboxIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/RequiredComboboxIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("required-combobox")
+public class RequiredComboboxIT extends AbstractComponentIT {
+
+    @Test
+    public void serverSideValidation_persistsOnBlur() {
+        open();
+
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+
+        // Select an invalid item
+        comboBox.openPopup();
+        executeScript(
+                "arguments[0].selectedItem = arguments[0].filteredItems[0]",
+                comboBox);
+
+        // The validation shows errors
+        assertValidationError(comboBox);
+
+        TestBenchElement msg = $(TestBenchElement.class).id("message");
+        Assert.assertEquals("Value changed from 'null' to 'foo'",
+                msg.getText());
+
+        // blur
+        msg.click();
+
+        // validation error is still shown
+        assertValidationError(comboBox);
+
+        // change the item to a valid one
+        comboBox.openPopup();
+        executeScript(
+                "arguments[0].selectedItem = arguments[0].filteredItems[1]",
+                comboBox);
+
+        // no invalid attribute
+        Assert.assertEquals(Boolean.FALSE.toString(),
+                comboBox.getAttribute("invalid"));
+        // the error message is not visible
+        TestBenchElement error = comboBox.$("vaadin-text-field").first()
+                .$(TestBenchElement.class).id("vaadin-text-field-error-0");
+        waitUntil(driver -> error.getSize().getHeight() == 0);
+    }
+
+    private void assertValidationError(ComboBoxElement comboBox) {
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                comboBox.getAttribute("invalid"));
+
+        TestBenchElement error = comboBox.$("vaadin-text-field").first()
+                .$(TestBenchElement.class).id("vaadin-text-field-error-0");
+        Assert.assertTrue(error.getSize().getHeight() > 0);
+        Assert.assertEquals("'foo' is invalid value", error.getText());
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/RequiredComboboxPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/RequiredComboboxPage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.bean.TestItem;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.router.Route;
+
+@Route("required-combobox")
+public class RequiredComboboxPage extends Div {
+
+    public RequiredComboboxPage() {
+        Div message = new Div();
+        message.setId("message");
+
+        Binder<TestItem> binder = new Binder<>();
+
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setItems("foo", "bar");
+        comboBox.addValueChangeListener(event -> message
+                .setText(String.format("Value changed from '%s' to '%s'",
+                        event.getOldValue(), event.getValue())));
+
+        binder.forField(comboBox).asRequired()
+                .withValidator(value -> !"foo".equals(value),
+                        "'foo' is invalid value")
+                .bind(TestItem::getName, TestItem::setName);
+        TestItem item = new TestItem(0);
+        binder.setBean(item);
+
+        add(comboBox, message);
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBoxElementUpdated;
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.Map;
+
+@TestPath("set-items-later")
+public class SetItemsLaterIT extends AbstractComponentIT {
+    @Before
+    public void init() {
+        open();
+        waitUntil(driver -> findElements(By.tagName("vaadin-combo-box"))
+                .size() > 0);
+    }
+
+    @Test
+    public void clickButton_comboBoxShouldContainsItems() {
+        open();
+        ComboBoxElement comboBox = $(ComboBoxElementUpdated.class).first();
+
+        List<Map<String, ?>> items = (List<Map<String, ?>>) executeScript(
+                "return arguments[0].filteredItems", comboBox);
+
+        Assert.assertNull("Items must be null.", items);
+
+        WebElement button = findElement(By.tagName("button"));
+        button.click();
+
+        items = (List<Map<String, ?>>) executeScript(
+                "return arguments[0].filteredItems", comboBox);
+
+        Assert.assertNotNull("Items must not be null.", items);
+
+        Assert.assertEquals("ComboBox must contain 2 items.",
+                2, items.size());
+
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 @TestPath("set-items-later")
-public class SetItemsLaterIT extends AbstractComponentIT {
+public class SetItemsLaterIT extends AbstractComboBoxIT {
     @Before
     public void init() {
         open();
@@ -42,21 +42,17 @@ public class SetItemsLaterIT extends AbstractComponentIT {
         open();
         ComboBoxElement comboBox = $(ComboBoxElementUpdated.class).first();
 
-        List<Map<String, ?>> items = (List<Map<String, ?>>) executeScript(
-                "return arguments[0].filteredItems", comboBox);
-
-        Assert.assertNull("Items must be null.", items);
+        waitForItems(comboBox, items -> items == null);
 
         WebElement button = findElement(By.tagName("button"));
         button.click();
 
-        items = (List<Map<String, ?>>) executeScript(
-                "return arguments[0].filteredItems", comboBox);
+        comboBox.openPopup();
 
-        Assert.assertNotNull("Items must not be null.", items);
-
-        Assert.assertEquals("ComboBox must contain 2 items.",
-                2, items.size());
+        waitForItems(comboBox, items -> items != null && items.size() == 2
+                && "foo".equals(getItemLabel(items, 0))
+                && "bar".equals(getItemLabel(items, 1))
+        );
 
     }
 

--- a/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterPage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterPage.java
@@ -1,0 +1,18 @@
+package com.vaadin.flow.component.combobox.test;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+
+@Route("set-items-later")
+public class SetItemsLaterPage extends VerticalLayout {
+
+    public SetItemsLaterPage() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        NativeButton button = new NativeButton("Click me to add items to the combobox",
+                event -> comboBox.setItems("foo", "bar"));
+        add(comboBox, button);
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInATemplate.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInATemplate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.template;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("combo-box-in-a-template")
+@HtmlImport("src/combo-box-in-a-template.html")
+public class ComboBoxInATemplate extends PolymerTemplate<TemplateModel> {
+
+    @Id
+    ComboBox<String> comboBox;
+
+    public ComboBox<String> getComboBox() {
+        return comboBox;
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInATemplate2.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInATemplate2.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.combobox.test;
+package com.vaadin.flow.component.combobox.test.template;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -22,15 +22,14 @@ import com.vaadin.flow.component.polymertemplate.Id;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
 import com.vaadin.flow.templatemodel.TemplateModel;
 
-@Tag("combo-box-in-a-template")
-@HtmlImport("src/combo-box-in-a-template.html")
-public class ComboBoxInATemplate extends PolymerTemplate<TemplateModel> {
+@Tag("combo-box-in-a-template2")
+@HtmlImport("src/combo-box-in-a-template2.html")
+public class ComboBoxInATemplate2 extends PolymerTemplate<TemplateModel> {
 
-    @Id
+    @Id("comboBox2")
     ComboBox<String> comboBox;
 
     public ComboBox<String> getComboBox() {
         return comboBox;
     }
-
 }

--- a/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInTemplateIT.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInTemplateIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.template;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("combo-box-in-template")
+public class ComboBoxInTemplateIT extends AbstractComponentIT {
+
+    private TestBenchElement message;
+    private ComboBoxElement box1;
+    private ComboBoxElement box2;
+
+    @Before
+    public void init() {
+        open();
+        message = $("label").id("message");
+        box1 = $("wrapper-template").first().$("combo-box-in-a-template")
+                .first().$(ComboBoxElement.class).first();
+        box2 = $("wrapper-template").first().$("combo-box-in-a-template2")
+                .first().$(ComboBoxElement.class).first();
+    }
+
+    @Test
+    // Test for https://github.com/vaadin/flow/issues/4862
+    public void twoLevelsOfTemplates_setValue_addValueChangeListener_noInitialValueChangeEvent() {
+        Assert.assertEquals("Value change event should not be fired.", "-",
+                message.getText());
+    }
+
+    @Test
+    public void twoLevelsOfTemplates_valueChangeEventsFired() {
+        box1.openPopup();
+        box1.setProperty("value", "2");
+        Assert.assertEquals("2", message.getText());
+
+        box2.openPopup();
+        box2.setProperty("value", "3");
+        Assert.assertEquals("3", message.getText());
+
+        box1.setProperty("value", "");
+        Assert.assertEquals("null", message.getText());
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInTemplatePage.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/template/ComboBoxInTemplatePage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.template;
+
+import java.util.Arrays;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.router.Route;
+
+@Route("combo-box-in-template")
+public class ComboBoxInTemplatePage extends Div {
+
+    private Label message;
+
+    public ComboBoxInTemplatePage() {
+        message = new Label("-");
+        message.setId("message");
+        add(message);
+
+        WrapperTemplate wrapper = new WrapperTemplate();
+        add(wrapper);
+
+        initCombo(wrapper.comboBoxInATemplate.getComboBox());
+        initCombo(wrapper.comboBoxInATemplate2.getComboBox());
+
+    }
+
+    private void initCombo(ComboBox<String> combo) {
+        combo.setDataProvider(
+                new ListDataProvider<>(Arrays.asList("1", "2", "3")));
+        combo.setValue("1");
+        combo.addValueChangeListener(e -> {
+            message.setText(e.getValue() == null ? "null" : e.getValue());
+        });
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/combobox/test/template/WrapperTemplate.java
+++ b/src/test/java/com/vaadin/flow/component/combobox/test/template/WrapperTemplate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test.template;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("wrapper-template")
+@HtmlImport("src/wrapper-template.html")
+public class WrapperTemplate extends PolymerTemplate<TemplateModel> {
+
+    @Id
+    ComboBoxInATemplate comboBoxInATemplate;
+
+    @Id
+    ComboBoxInATemplate2 comboBoxInATemplate2;
+}

--- a/src/test/webapp/frontend/src/combo-box-in-a-template2.html
+++ b/src/test/webapp/frontend/src/combo-box-in-a-template2.html
@@ -14,18 +14,16 @@
   ~ the License.
   -->
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-
-<dom-module id="combo-box-in-a-template">
+<dom-module id="combo-box-in-a-template2">
     <template>
-        <vaadin-combo-box id="comboBox"></vaadin-combo-box>
+        <vaadin-combo-box id="comboBox2"></vaadin-combo-box>
     </template>
-
     <script>
-        class ComboBoxInATemplate extends Polymer.Element {
+        class ComboBoxInATemplate2 extends Polymer.Element {
             static get is() {
-                return 'combo-box-in-a-template'
+                return 'combo-box-in-a-template2'
             }
         }
-        customElements.define(ComboBoxInATemplate.is, ComboBoxInATemplate);
+        customElements.define(ComboBoxInATemplate2.is, ComboBoxInATemplate2);
     </script>
 </dom-module>

--- a/src/test/webapp/frontend/src/wrapper-template.html
+++ b/src/test/webapp/frontend/src/wrapper-template.html
@@ -14,18 +14,19 @@
   ~ the License.
   -->
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
-
-<dom-module id="combo-box-in-a-template">
+<dom-module id="wrapper-template">
     <template>
-        <vaadin-combo-box id="comboBox"></vaadin-combo-box>
+        <combo-box-in-a-template
+                id="comboBoxInATemplate"></combo-box-in-a-template>
+        <combo-box-in-a-template2
+                id="comboBoxInATemplate2"></combo-box-in-a-template2>
     </template>
-
     <script>
-        class ComboBoxInATemplate extends Polymer.Element {
+        class WrapperTemplate extends Polymer.Element {
             static get is() {
-                return 'combo-box-in-a-template'
+                return 'wrapper-template'
             }
         }
-        customElements.define(ComboBoxInATemplate.is, ComboBoxInATemplate);
+        customElements.define(WrapperTemplate.is, WrapperTemplate);
     </script>
 </dom-module>


### PR DESCRIPTION
Cherry-picks:
- removed obsolete jetty version (#165) 
- Set value-property with js as a workaround (#174) 
- Fix: value is not updated when null in ComboBox (#186) 
- Add IT test for #186. (#189) 
-  Initialize $connector if values were not set in ComboBox element prior to page load. (#188)
- IT test for #188 (#190) 
- Set filter on autofocus combobox (#191) 
- Client side filter fix. (#192)
- Disable client side validation on setRequiredIndicatorVisible (#202)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/203)
<!-- Reviewable:end -->
