### PR TITLE
Add maven profile to use bower in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ reference-screenshots
 .idea/
 
 **/bower_components/**
+**/node_modules/**
+**/node/**
+**/package-lock.json

--- a/vaadin-combo-box-flow-integration-tests/build-tools/package.json
+++ b/vaadin-combo-box-flow-integration-tests/build-tools/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vaadin-combo-box-flow-integration-tests",
+  "description": "Frontend dependencies for vaadin-combo-box-flow integration tests",
+  "version": "1.0.0",
+  "author": "Vaadin Ltd",
+  "license": "SEE LICENSE IN https://vaadin.com/license/cval-3.0",
+  "devDependencies": {
+    "bower": "1.8.2"
+  },
+  "scripts": {
+    "install-bower-and-dependencies": "npm install && cd ../src/main/webapp/frontend && bower install",
+    "build": "cd ../src/main/webapp/frontend && bower install && polymer build"
+  },
+  "dependencies": {
+    "polymer-cli": "^1.5.7",
+    "rimraf": "^2.6.2"
+  }
+}

--- a/vaadin-combo-box-flow-integration-tests/pom.xml
+++ b/vaadin-combo-box-flow-integration-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -91,7 +91,7 @@
             <version>${flow.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
@@ -102,6 +102,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>src/main/webapp/frontend</directory>
+                            <includes>
+                                <include>bower_components/</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
@@ -140,6 +153,66 @@
                     <plugin>
                         <groupId>com.lazerycode.selenium</groupId>
                         <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--This profile is only present for quick testing againt the element from GitHub-->
+        <!--Do not use with production mode-->
+        <profile>
+            <id>bower</id>
+            <activation>
+                <property>
+                    <name>useBower</name>
+                </property>
+            </activation>
+
+            <properties>
+                <buildtools.directory>build-tools</buildtools.directory>
+
+                <!-- Not the newest version because of https://www.polymer-project.org/2.0/docs/tools/node-support -->
+                <frontend.maven.plugin.version>1.6</frontend.maven.plugin.version>
+                <node.version>v8.9.0</node.version>
+                <yarn.version>v1.3.2</yarn.version>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>${frontend.maven.plugin.version}</version>
+
+                        <configuration>
+                            <nodeVersion>${node.version}</nodeVersion>
+                            <yarnVersion>${yarn.version}</yarnVersion>
+                            <workingDirectory>${buildtools.directory}</workingDirectory>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>install-tools-then-build</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <workingDirectory>${buildtools.directory}</workingDirectory>
+                                    <arguments>install-bower-and-dependencies</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <configuration>
+                            <webAppConfig>
+                                <resourceBases combine.children="append">
+                                    <resourceBase>${project.basedir}/src/main/webapp</resourceBase>
+                                </resourceBases>
+                            </webAppConfig>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-combo-box-flow-integration-tests/src/main/webapp/frontend/bower.json
+++ b/vaadin-combo-box-flow-integration-tests/src/main/webapp/frontend/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "vaadin-combo-box",
+  "homepage": "https://github.com/vaadin/vaadin-combo-box",
+  "authors": [],
+  "description": "",
+  "main": "",
+  "license": "Apache License v2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "vaadin-combo-box": "vaadin/vaadin-combo-box#master"
+  }
+}


### PR DESCRIPTION
This allows installing any GitHub branch of the web component, to test how
the changes in the web component affect the Flow counterpart, by
defining the property -DuseBower. The branch can be specified in the
added bower.json (default is master).
Running 'mvn clean' will remove the bower components.

The configuration is based on vaadin-crud-flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/204)
<!-- Reviewable:end -->
