### PR TITLE
Add IT for resolving loading state when 0 items returned

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.combobox.test;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -55,6 +56,8 @@ public class LazyLoadingPage extends Div {
         createCallbackDataProvider();
         addSeparator();
         createComboBoxInATemplate();
+        addSeparator();
+        createCallbackDataProviderWhichReturnsZeroItems();
     }
 
     private void createListDataProviderWithStrings() {
@@ -200,6 +203,21 @@ public class LazyLoadingPage extends Div {
         comboBox.addValueChangeListener(e -> message.setText(e.getValue()));
 
         add(comboBoxInATemplate);
+    }
+
+    private void createCallbackDataProviderWhichReturnsZeroItems() {
+        addTitle("Callback data provider returns zero items");
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("empty-callback");
+
+        List<String> items = Collections.emptyList();
+        CallbackDataProvider.FetchCallback<String, String> fetch = query -> items
+                .stream().limit(query.getLimit()).skip(query.getOffset());
+        CallbackDataProvider.CountCallback<String, String> count = query -> 0;
+        comboBox.setDataProvider(
+                DataProvider.fromFilteringCallbacks(fetch, count));
+
+        add(comboBox);
     }
 
     public static List<String> generateStrings(int count) {

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -38,6 +38,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     private ComboBoxElement filterBox;
     private ComboBoxElement callbackBox;
     private ComboBoxElement templateBox;
+    private ComboBoxElement emptyCallbackBox;
 
     @Before
     public void init() {
@@ -51,6 +52,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         callbackBox = $(ComboBoxElement.class).id("callback-dataprovider");
         templateBox = $("combo-box-in-a-template").id("template")
                 .$(ComboBoxElement.class).first();
+        emptyCallbackBox = $(ComboBoxElement.class).id("empty-callback");
     }
 
     @Test
@@ -341,6 +343,18 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
                 "Expected no items to be loaded after setting "
                         + "a filter which doesn't match any item",
                 0, stringBox);
+    }
+
+    @Test
+    public void callbackDataProviderReturnsNoItems_openMultipleTimes_loadingStateResolved() {
+        for (int i = 0; i < 3; i++) {
+            emptyCallbackBox.openPopup();
+            waitUntil(
+                    driver -> !emptyCallbackBox.getPropertyBoolean("loading"));
+            assertLoadedItemsCount("Expected no items to be loaded", 0,
+                    emptyCallbackBox);
+            emptyCallbackBox.closePopup();
+        }
     }
 
     @Test


### PR DESCRIPTION
Test for a bug fixed in the web component:
https://github.com/vaadin/vaadin-combo-box/pull/772

Close #178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/206)
<!-- Reviewable:end -->
