### PR TITLE
Update only one item on DataProvider::refreshItem

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/bean/SimpleBean.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/bean/SimpleBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.bean;
+
+public class SimpleBean {
+    private String name;
+
+    public SimpleBean(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/RefreshDataProviderPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/RefreshDataProviderPage.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.bean.SimpleBean;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -34,6 +36,12 @@ public class RefreshDataProviderPage extends Div {
             .ofCollection(nameList);
 
     public RefreshDataProviderPage() {
+        createRefreshAll();
+        add(new Hr());
+        createRefreshItem();
+    }
+
+    private void createRefreshAll() {
         NativeButton update = new NativeButton("Update");
         update.addClickListener(event -> addNames());
         update.setId("update");
@@ -48,5 +56,25 @@ public class RefreshDataProviderPage extends Div {
         nameList.add("foo");
         nameList.add("bar");
         provider.refreshAll();
+    }
+
+    private void createRefreshItem() {
+        SimpleBean item1 = new SimpleBean("foo");
+        SimpleBean item2 = new SimpleBean("bar");
+
+        ComboBox<SimpleBean> comboBox = new ComboBox<>();
+        comboBox.setItemLabelGenerator(SimpleBean::getName);
+        comboBox.setId("refresh-item-combo-box");
+        comboBox.setItems(item1, item2);
+
+        NativeButton button = new NativeButton(
+                "Change both items, refresh only the second one", e -> {
+                    item1.setName("foo updated");
+                    item2.setName("bar updated");
+                    comboBox.getDataProvider().refreshItem(item2);
+                });
+        button.setId("refresh-item");
+
+        add(comboBox, button);
     }
 }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
+import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
@@ -505,14 +506,19 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
 
-        dataProvider.addDataProviderListener(
-                e -> dataProviderUpdated(shouldForceServerSideFiltering));
-        dataProviderUpdated(shouldForceServerSideFiltering);
+        dataProvider.addDataProviderListener(e -> {
+            if (e instanceof DataRefreshEvent) {
+                dataCommunicator.refresh(((DataRefreshEvent<T>) e).getItem());
+            } else {
+                refreshAllData(shouldForceServerSideFiltering);
+            }
+        });
+        refreshAllData(shouldForceServerSideFiltering);
 
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
 
-    private void dataProviderUpdated(boolean forceServerSideFiltering) {
+    private void refreshAllData(boolean forceServerSideFiltering) {
         int size = getDataProvider().size(new Query<>());
         setClientSideFilter(
                 !forceServerSideFiltering && size <= getPageSizeDouble());


### PR DESCRIPTION
Fix #184

The client-side part was already implemented in the connector, just never triggered by the data refresh event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/209)
<!-- Reviewable:end -->
