### PR TITLE
Update value-property on setValue

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/LazyLoadingPage.java
@@ -81,7 +81,13 @@ public class LazyLoadingPage extends Div {
         });
         disableButton.setId("disable");
 
-        add(comboBox, setButton, disableButton);
+        NativeButton setCurrentValueButton = new NativeButton(
+                "set current value", e -> {
+                    comboBox.setValue(comboBox.getValue());
+                });
+        setCurrentValueButton.setId("set-current-value");
+
+        add(comboBox, setButton, disableButton, setCurrentValueButton);
     }
 
     private void createComboBoxWithCustomPageSize() {

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -394,6 +394,21 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertRendered("Item 52");
     }
 
+    @Test // https://github.com/vaadin/vaadin-combo-box-flow/issues/216
+    public void filterAndSelectItemNotOnFirstPage_setCurrentValue_valueCorrect() {
+        String item = "Item 151";
+
+        stringBox.openPopup();
+        stringBox.setFilter(item);
+        waitUntil(driver -> getNonEmptyOverlayContents().size() == 1);
+        stringBox.selectByText(item);
+
+        clickButton("set-current-value");
+
+        assertMessage(item);
+        Assert.assertEquals(item, getSelectedItemLabel(stringBox));
+    }
+
     private void assertMessage(String expectedMessage) {
         Assert.assertEquals(expectedMessage, $("div").id("message").getText());
     }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -343,6 +343,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         json.put("key", keyMapper.key(value));
         dataGenerator.generateData(value, json);
         setSelectedItem(json);
+        getElement().setProperty("value", keyMapper.key(value));
 
         // Workaround for property not updating in certain scenario
         // https://github.com/vaadin/flow/issues/4862


### PR DESCRIPTION
Fix #216

The problem was that the server-side value-property did not match the
key of the set item. When the value-prop was later set with js as a
workaround for a Flow bug (see the lines below the added line in
ComboBox.java), that value did not match the selectedItem, which caused
the value to become null.

(Note: server-side key is used as the client-side value-property)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/229)
<!-- Reviewable:end -->
