### PR TITLE
Avoid calling DataProvider::size when it's not needed

### DIFF
--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -519,9 +519,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void refreshAllData(boolean forceServerSideFiltering) {
-        int size = getDataProvider().size(new Query<>());
-        setClientSideFilter(
-                !forceServerSideFiltering && size <= getPageSizeDouble());
+        setClientSideFilter(!forceServerSideFiltering && getDataProvider()
+                .size(new Query<>()) <= getPageSizeDouble());
 
         reset();
     }


### PR DESCRIPTION
Now it is not called when using a lazy data provider, because
- the size is used to check if client-side filtering can be used
- lazy data providers always handle filtering in server-side anyway

Fix #222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/230)
<!-- Reviewable:end -->
