### PR TITLE
Don't apply new filter to DP if filter not changed

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -95,6 +95,11 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
                 matchingItem.isPresent());
     }
 
+    protected void assertComponentRendered(String componentHtml) {
+        assertRendered("<flow-component-renderer appid=\"ROOT\">"
+                + componentHtml + "</flow-component-renderer>");
+    }
+
     // Gets the innerHTML of all the actually rendered item elements.
     // There's more items loaded though.
     protected List<String> getOverlayContents() {

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -234,8 +234,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         beanBox.openPopup();
         clickButton("component-renderer");
         beanBox.openPopup();
-        assertRendered("<flow-component-renderer appid=\"ROOT\">"
-                + "<h4>Person 4</h4></flow-component-renderer>");
+        assertComponentRendered("<h4>Person 4</h4>");
         assertLoadedItemsCount("Only the first page should be loaded.", 50,
                 beanBox);
     }
@@ -256,8 +255,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         clickButton("item-label-generator");
         clickButton("component-renderer");
         beanBox.openPopup();
-        assertRendered("<flow-component-renderer appid=\"ROOT\">"
-                + "<h4>Person 4</h4></flow-component-renderer>");
+        assertComponentRendered("<h4>Person 4</h4>");
         getItemElements().get(7).click();
         Assert.assertEquals("Born 7", getTextFieldValue(beanBox));
 
@@ -407,6 +405,18 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
 
         assertMessage(item);
         Assert.assertEquals(item, getSelectedItemLabel(stringBox));
+    }
+
+    @Test // https://github.com/vaadin/vaadin-combo-box-flow/issues/227
+    public void setComponentRenderer_scrollDown_scrollUp_itemsRendered() {
+        clickButton("component-renderer");
+        beanBox.openPopup();
+        scrollToItem(beanBox, 300);
+        scrollToItem(beanBox, 0);
+
+        assertComponentRendered("<h4>Person 0</h4>");
+        assertComponentRendered("<h4>Person 4</h4>");
+        assertComponentRendered("<h4>Person 9</h4>");
     }
 
     private void assertMessage(String expectedMessage) {

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -159,8 +159,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             enqueue("$connector.confirm", updateId, ComboBox.this.lastFilter);
             queue.forEach(Runnable::run);
             queue.clear();
-
-            ComboBox.this.lastFilter = null;
         }
 
         private void enqueue(String name, Serializable... arguments) {
@@ -938,10 +936,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @ClientCallable
     private void setRequestedRange(int start, int length, String filter) {
-        this.lastFilter = filter;
-
         dataCommunicator.setRequestedRange(start, length);
-        filterSlot.accept(filter);
+        if (!Objects.equals(filter, lastFilter)) {
+            lastFilter = filter;
+            filterSlot.accept(filter);
+        }
     }
 
     @ClientCallable

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -500,8 +500,12 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                 .setDataProvider(dataProvider,
                         convertOrNull.apply(getFilterString()));
 
-        filterSlot = filter -> providerFilterSlot
-                .accept(convertOrNull.apply(filter));
+        filterSlot = filter -> {
+            if (!Objects.equals(filter, lastFilter)) {
+                providerFilterSlot.accept(convertOrNull.apply(filter));
+                lastFilter = filter;
+            }
+        };
 
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
 
@@ -937,10 +941,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     @ClientCallable
     private void setRequestedRange(int start, int length, String filter) {
         dataCommunicator.setRequestedRange(start, length);
-        if (!Objects.equals(filter, lastFilter)) {
-            lastFilter = filter;
-            filterSlot.accept(filter);
-        }
+        filterSlot.accept(filter);
     }
 
     @ClientCallable


### PR DESCRIPTION
Otherwise, DataProvider will get a new instance of the filter object
-> DataCommunicator thinks filter changed
-> destroys all data
-> rendered components are destroyed
-> client still thinks that everything is fine
-> flow-component-renderer doesn't find destroyed component instances
-> components not rendered

Fix #227

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/231)
<!-- Reviewable:end -->
