### PR TITLE
Disable iron-list's focus management

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/AbstractComboBoxIT.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.combobox.test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -119,9 +120,14 @@ public class AbstractComboBoxIT extends AbstractComponentIT {
     }
 
     protected List<TestBenchElement> getItemElements() {
+        TestBenchElement focusBackfillItem = getOverlay().$("div").id("content")
+                .$("iron-list").first()
+                .getPropertyElement("_focusBackfillItem");
+
         return getOverlay().$("div").id("content").$("vaadin-combo-box-item")
                 .all().stream()
                 .filter(element -> !element.hasAttribute("hidden"))
+                .filter(element -> !Objects.equals(focusBackfillItem, element))
                 .collect(Collectors.toList());
     }
 

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -407,7 +407,9 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         Assert.assertEquals(item, getSelectedItemLabel(stringBox));
     }
 
-    @Test // https://github.com/vaadin/vaadin-combo-box-flow/issues/227
+    @Test
+    // https://github.com/vaadin/vaadin-combo-box-flow/issues/227
+    // https://github.com/vaadin/vaadin-combo-box-flow/issues/232
     public void setComponentRenderer_scrollDown_scrollUp_itemsRendered() {
         clickButton("component-renderer");
         beanBox.openPopup();

--- a/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -251,5 +251,9 @@ window.Vaadin.Flow.comboBoxConnector = {
 
       callback(filteredItems, filteredItems.length);
     }
+
+    // https://github.com/vaadin/vaadin-combo-box-flow/issues/232
+    comboBox.addEventListener('opened-changed', e =>
+      e.detail.value && (comboBox.$.overlay._selector._manageFocus = () => {}));
   }
 }


### PR DESCRIPTION
because it breaks flow-component-renderer.
Fix #232

Any other solutions would be a lot more complex workarounds. Since iron-list does not provide any kind of API for reacting to focus item changes, we should somehow recognize in the `flow-component-renderer` when its child is detached, or when the first item is scrolled back into the view, and call `_attachRenderedComponentIfAble()`.

I think this workaround is the best solution, as it's a one-liner and does not require creating a custom `flow-component-renderer` for combo box.

A note about the test: the existing test case covers this when we exclude the focus item from the found item elements (it's "hidden" by translating it out of the viewport).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/234)
<!-- Reviewable:end -->
