### PR TITLE
Improve flaky test

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -379,6 +379,7 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
         assertLoadedItemsCount(
                 "After opening the ComboBox, the first 50 items should be loaded",
                 50, templateBox);
+        assertRendered("Item 8");
 
         getItemElements().get(8).click();
         assertMessage("Item 8");


### PR DESCRIPTION
The assertRendered helper waits for some content to be actually visible
in the items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/251)
<!-- Reviewable:end -->
