### PR TITLE
Init with empty data set if user doesn't provide data

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/SetItemsLaterIT.java
@@ -51,4 +51,24 @@ public class SetItemsLaterIT extends AbstractComboBoxIT {
 
     }
 
+    @Test
+    public void dontSetItemsOrDataProvider_openComboBox_loadingStateResolved() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        comboBox.openPopup();
+        waitUntil(driver -> !comboBox.getPropertyBoolean("loading"));
+        assertLoadedItemsCount("ComboBox should not have items", 0, comboBox);
+    }
+
+    @Test
+    public void openEmptyComboBox_setItems_open_containsItems() {
+        ComboBoxElement comboBox = $(ComboBoxElement.class).first();
+        comboBox.openPopup();
+        findElement(By.tagName("button")).click();
+        comboBox.openPopup();
+        assertLoadedItemsCount("ComboBox should have loaded 2 items", 2,
+                comboBox);
+        assertRendered("foo");
+        assertRendered("bar");
+    }
+
 }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -246,7 +246,14 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         setItemValuePath("key");
         setItemIdPath("key");
         setPageSize(pageSize);
+
         initConnector();
+        runBeforeClientResponse(ui -> {
+            // If user didn't provide any data, initialize with empty data set.
+            if (dataCommunicator == null) {
+                setItems();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
The DataCommunicator etc. need to be initialized so that ComboBox
can respond to the request from the client-side dataProvider.

Fix #253