### PR TITLE
Prevent default on custom-value-set, improve javadocs

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/CustomValuePage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/CustomValuePage.java
@@ -40,13 +40,10 @@ public class CustomValuePage extends Div {
         valueMessages.setId("value-messages");
 
         combo.setItems(items);
-        combo.addCustomValueSetListener(e -> {
-            customValueMessages.add(new Paragraph(e.getDetail()));
-        });
-        combo.addValueChangeListener(e -> {
-            valueMessages.add(new Paragraph(
-                    e.getValue() == null ? "null" : e.getValue()));
-        });
+        combo.addCustomValueSetListener(
+                e -> customValueMessages.add(new Paragraph(e.getDetail())));
+        combo.addValueChangeListener(e -> valueMessages.add(
+                new Paragraph(e.getValue() == null ? "null" : e.getValue())));
 
         add(combo, new H3("custom value changes:"), customValueMessages,
                 new H3("combo box value changes:"), valueMessages);
@@ -65,9 +62,7 @@ public class CustomValuePage extends Div {
     }
 
     private void setComboBoxToSetCustomValuesAsValue(ComboBox<String> combo) {
-        combo.addCustomValueSetListener(e -> {
-            combo.setValue(e.getDetail());
-        });
+        combo.addCustomValueSetListener(e -> combo.setValue(e.getDetail()));
     }
 
     private void setComboBoxToAddCustomValuesToData(ComboBox<String> combo) {

--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/CustomValuePage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/CustomValuePage.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.router.Route;
+
+@Route("custom-value")
+public class CustomValuePage extends Div {
+
+    private ComboBox<String> combo = new ComboBox<>();
+    private List<String> items = new ArrayList<>();
+
+    public CustomValuePage() {
+        items.add("foo");
+
+        Div customValueMessages = new Div();
+        customValueMessages.setId("custom-value-messages");
+        Div valueMessages = new Div();
+        valueMessages.setId("value-messages");
+
+        combo.setItems(items);
+        combo.addCustomValueSetListener(e -> {
+            customValueMessages.add(new Paragraph(e.getDetail()));
+        });
+        combo.addValueChangeListener(e -> {
+            valueMessages.add(new Paragraph(
+                    e.getValue() == null ? "null" : e.getValue()));
+        });
+
+        add(combo, new H3("custom value changes:"), customValueMessages,
+                new H3("combo box value changes:"), valueMessages);
+
+        // Allow configuring common use cases
+        NativeButton button1 = new NativeButton(
+                "set custom value as combo box value",
+                e -> setComboBoxToSetCustomValuesAsValue(combo));
+        button1.setId("set-custom-values-as-value");
+
+        NativeButton button2 = new NativeButton("add custom values to data set",
+                e -> setComboBoxToAddCustomValuesToData(combo));
+        button2.setId("add-custom-values-to-data");
+
+        add(new H3("config common use cases:"), button1, button2);
+    }
+
+    private void setComboBoxToSetCustomValuesAsValue(ComboBox<String> combo) {
+        combo.addCustomValueSetListener(e -> {
+            combo.setValue(e.getDetail());
+        });
+    }
+
+    private void setComboBoxToAddCustomValuesToData(ComboBox<String> combo) {
+        combo.addCustomValueSetListener(e -> {
+            items.add(e.getDetail());
+            combo.getDataProvider().refreshAll();
+        });
+    }
+
+}

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
@@ -58,13 +58,17 @@ public class CustomValueIT extends AbstractComboBoxIT {
 
     @Test
     public void typeAndEnterExistingValue_noCustomValueChanges() {
-        combo.sendKeys("foo", Keys.ENTER);
+        combo.sendKeys("foo");
+        assertRendered("foo");
+        combo.sendKeys(Keys.ENTER);
         assertCustomValueChanges();
     }
 
     @Test
     public void typeAndEnterExistingValue_valueChanged() {
-        combo.sendKeys("foo", Keys.ENTER);
+        combo.sendKeys("foo");
+        assertRendered("foo");
+        combo.sendKeys(Keys.ENTER);
         assertValueChanges("foo");
     }
 
@@ -79,7 +83,9 @@ public class CustomValueIT extends AbstractComboBoxIT {
 
     @Test
     public void enterExistingValue_clearAndEnter_noCustomValueChange() {
-        combo.sendKeys("foo", Keys.ENTER);
+        combo.sendKeys("foo");
+        assertRendered("foo");
+        combo.sendKeys(Keys.ENTER);
         repeatKey(Keys.BACK_SPACE, 3);
         combo.sendKeys(Keys.ENTER);
         assertCustomValueChanges();
@@ -87,7 +93,9 @@ public class CustomValueIT extends AbstractComboBoxIT {
 
     @Test
     public void enterExistingValue_clearAndEnter_valueChangedToNull() {
-        combo.sendKeys("foo", Keys.ENTER);
+        combo.sendKeys("foo");
+        assertRendered("foo");
+        combo.sendKeys(Keys.ENTER);
         repeatKey(Keys.BACK_SPACE, 3);
         combo.sendKeys(Keys.ENTER);
         assertValueChanges("foo", "null");

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
@@ -144,23 +144,35 @@ public class CustomValueIT extends AbstractComboBoxIT {
     }
 
     private void assertCustomValueChanges(String... expected) {
-        String[] customValueChanges = $(TestBenchElement.class)
-                .id("custom-value-messages").$("p").all().stream()
-                .map(TestBenchElement::getText).toArray(String[]::new);
-        Assert.assertArrayEquals(
-                "Unexpected custom value changes for ComboBox: "
-                        + String.join(", ", customValueChanges),
-                expected, customValueChanges);
+        assertMessages(true, expected);
     }
 
     private void assertValueChanges(String... expected) {
-        String[] valueMessages = $(TestBenchElement.class).id("value-messages")
-                .$("p").all().stream().map(TestBenchElement::getText)
-                .toArray(String[]::new);
+        assertMessages(false, expected);
+    }
+
+    private String[] messages;
+
+    private void assertMessages(boolean customValues, String... expected) {
+        String containerId = customValues ? "custom-value-messages"
+                : "value-messages";
+        String valueName = customValues ? "custom value" : "value";
+
+        try {
+            waitUntil(driver -> {
+                messages = $(TestBenchElement.class).id(containerId).$("p")
+                        .all().stream().map(TestBenchElement::getText)
+                        .toArray(String[]::new);
+                return messages.length == expected.length;
+            }, 5);
+        } catch (Exception e) {
+            Assert.fail(String.format(
+                    "\nExpected %s changes: [%s]\nbut was: [%s]\n", valueName,
+                    String.join(", ", expected), String.join(", ", messages)));
+        }
         Assert.assertArrayEquals(
-                "Unexpected value changes for ComboBox: "
-                        + String.join(", ", valueMessages),
-                expected, valueMessages);
+                String.format("Unexpected %s changes for ComboBox", valueName),
+                expected, messages);
     }
 
     private void repeatKey(Keys key, int amount) {

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/CustomValueIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.combobox.test;
+
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+
+@TestPath("custom-value")
+public class CustomValueIT extends AbstractComboBoxIT {
+
+    ComboBoxElement combo;
+
+    @Before
+    public void init() {
+        open();
+        combo = $(ComboBoxElement.class).first();
+    }
+
+    @Test
+    public void inputKeys_noEvents() {
+        combo.sendKeys("bar");
+        assertCustomValueChanges();
+        assertValueChanges();
+    }
+
+    @Test
+    public void inputAndEnter_customValueSetEventFiredWithInputValue() {
+        combo.sendKeys("bar", Keys.ENTER);
+        assertCustomValueChanges("bar");
+    }
+
+    @Test
+    public void inputAndEnter_comboBoxValueNotChanged() {
+        combo.sendKeys("bar", Keys.ENTER);
+        assertValueChanges();
+    }
+
+    @Test
+    public void typeAndEnterExistingValue_noCustomValueChanges() {
+        combo.sendKeys("foo", Keys.ENTER);
+        assertCustomValueChanges();
+    }
+
+    @Test
+    public void typeAndEnterExistingValue_valueChanged() {
+        combo.sendKeys("foo", Keys.ENTER);
+        assertValueChanges("foo");
+    }
+
+    @Test
+    public void enterCustomValue_clearAndEnter_noNewEvents() {
+        combo.sendKeys("bar", Keys.ENTER);
+        repeatKey(Keys.BACK_SPACE, 3);
+        combo.sendKeys(Keys.ENTER);
+        assertCustomValueChanges("bar");
+        assertValueChanges();
+    }
+
+    @Test
+    public void enterExistingValue_clearAndEnter_noCustomValueChange() {
+        combo.sendKeys("foo", Keys.ENTER);
+        repeatKey(Keys.BACK_SPACE, 3);
+        combo.sendKeys(Keys.ENTER);
+        assertCustomValueChanges();
+    }
+
+    @Test
+    public void enterExistingValue_clearAndEnter_valueChangedToNull() {
+        combo.sendKeys("foo", Keys.ENTER);
+        repeatKey(Keys.BACK_SPACE, 3);
+        combo.sendKeys(Keys.ENTER);
+        assertValueChanges("foo", "null");
+    }
+
+    @Test
+    public void setCustomValueAsValue_enterCustomValue_valueChanged() {
+        clickButton("set-custom-values-as-value");
+        combo.sendKeys("bar", Keys.ENTER);
+        assertCustomValueChanges("bar");
+        assertValueChanges("bar");
+    }
+
+    @Test
+    // Executing more complex sequence in a common use case
+    public void addCustomValueToDataAndSetAsValue_testUseCase() {
+        clickButton("add-custom-values-to-data");
+        clickButton("set-custom-values-as-value");
+
+        combo.sendKeys("bar", Keys.ENTER);
+        assertCustomValueChanges("bar");
+        assertValueChanges("bar");
+
+        combo.openPopup();
+        assertLoadedItemsCount(
+                "Expected 2 items to be loaded after adding the custom value",
+                2, combo);
+        assertRendered("foo");
+        assertRendered("bar");
+        assertItemSelected("bar");
+
+        repeatKey(Keys.BACK_SPACE, 3);
+        combo.sendKeys("foo", Keys.ENTER);
+        assertCustomValueChanges("bar");
+        assertValueChanges("bar", "foo");
+        combo.openPopup();
+        assertLoadedItemsCount("Expected 2 items to be loaded", 2, combo);
+        assertItemSelected("foo");
+
+        combo.sendKeys("baz", Keys.ENTER);
+        assertCustomValueChanges("bar", "foobaz");
+        assertValueChanges("bar", "foo", "foobaz");
+        combo.openPopup();
+        assertLoadedItemsCount(
+                "Expected 3 items to be loaded after adding the custom value",
+                3, combo);
+        assertItemSelected("foobaz");
+
+        repeatKey(Keys.BACK_SPACE, 6);
+        combo.sendKeys(Keys.ENTER);
+
+        assertCustomValueChanges("bar", "foobaz");
+        assertValueChanges("bar", "foo", "foobaz", "null");
+    }
+
+    private void assertCustomValueChanges(String... expected) {
+        String[] customValueChanges = $(TestBenchElement.class)
+                .id("custom-value-messages").$("p").all().stream()
+                .map(TestBenchElement::getText).toArray(String[]::new);
+        Assert.assertArrayEquals(
+                "Unexpected custom value changes for ComboBox: "
+                        + String.join(", ", customValueChanges),
+                expected, customValueChanges);
+    }
+
+    private void assertValueChanges(String... expected) {
+        String[] valueMessages = $(TestBenchElement.class).id("value-messages")
+                .$("p").all().stream().map(TestBenchElement::getText)
+                .toArray(String[]::new);
+        Assert.assertArrayEquals(
+                "Unexpected value changes for ComboBox: "
+                        + String.join(", ", valueMessages),
+                expected, valueMessages);
+    }
+
+    private void repeatKey(Keys key, int amount) {
+        IntStream.range(0, amount).forEach(i -> combo.sendKeys(key));
+    }
+
+}

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -742,22 +742,47 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         return getErrorMessageString();
     }
 
+    /**
+     * Enables or disables the component firing events for custom string input.
+     * <p>
+     * When enabled, a {@link CustomValueSetEvent} will be fired when the user
+     * inputs a string value that does not match any existing items and commits
+     * it eg. by blurring or pressing the enter-key.
+     * <p>
+     * Note that ComboBox doesn't do anything with the custom value string
+     * automatically. Use the
+     * {@link #addCustomValueSetListener(ComponentEventListener)} method to
+     * determine how the custom value should be handled. For example, when the
+     * ComboBox has {@code String} as the value type, you can add a listener
+     * which sets the custom string as the value of the ComboBox with
+     * {@link #setValue(Object)}.
+     * <p>
+     * Setting to {@code true} also allows an unfocused ComboBox to display a
+     * string that doesn't match any of its items nor its current value, unless
+     * this is explicitly handled with
+     * {@link #addCustomValueSetListener(ComponentEventListener)}. When set to
+     * {@code false}, an unfocused ComboBox will always display the label of the
+     * currently selected item.
+     * 
+     * @param allowCustomValue
+     *            {@code true} to enable custom value set events, {@code false}
+     *            to disable them
+     * @see #addCustomValueSetListener(ComponentEventListener)
+     */
     @Override
     public void setAllowCustomValue(boolean allowCustomValue) {
         super.setAllowCustomValue(allowCustomValue);
     }
 
     /**
-     * If {@code true}, the user can input a value that is not present in the
-     * items list. {@code value} property will be set to the input value in this
-     * case. Also, when {@code value} is set programmatically, the input value
-     * will be set to reflect that value.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
+     * If {@code true}, the user can input string values that do not match to
+     * any existing item labels, which will fire a {@link CustomValueSetEvent}.
      *
-     * @return the {@code allowCustomValue} property from the combobox
+     * @return {@code true} if the component fires custom value set events,
+     *         {@code false} otherwise
+     *
+     * @see #setAllowCustomValue(boolean)
+     * @see #addCustomValueSetListener(ComponentEventListener)
      */
     public boolean isAllowCustomValue() {
         return isAllowCustomValueBoolean();
@@ -868,20 +893,23 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     /**
-     * Adds a listener for CustomValueSetEvent which is fired when user types in
-     * a value that don't already exist in the ComboBox.
-     *
+     * Adds a listener for the event which is fired when user inputs a string
+     * value that does not match any existing items and commits it eg. by
+     * blurring or pressing the enter-key.
      * <p>
-     * As a side effect makes the ComboBox allow custom values. If you don't
-     * want to allow a user to add new values to the list once the listener is
-     * added please disable it explicitly via the
+     * Note that ComboBox doesn't do anything with the custom value string
+     * automatically. Use this method to determine how the custom value should
+     * be handled. For example, when the ComboBox has {@code String} as the
+     * value type, you can add a listener which sets the custom string as the
+     * value of the ComboBox with {@link #setValue(Object)}.
+     * <p>
+     * As a side effect, this makes the ComboBox allow custom values. If you
+     * want to disable the firing of custom value set events once the listener
+     * is added, please disable it explicitly via the
      * {@link #setAllowCustomValue(boolean)} method.
-     * </p>
-     *
      * <p>
      * The custom value becomes disallowed automatically once the last custom
      * value set listener is removed.
-     * </p>
      *
      * @param listener
      *            the listener to be notified when a new value is filled

--- a/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -174,11 +174,11 @@ window.Vaadin.Flow.comboBoxConnector = {
       // Let server know we're done
       comboBox.$server.confirmUpdate(id);
     }
-    
+
     comboBox.$connector.enableClientValidation = function( enable ){
         let input = null;
         if ( comboBox.$ ){
-            input = comboBox.$["input"]; 
+            input = comboBox.$["input"];
         }
         if (input){
             if ( enable){
@@ -191,12 +191,12 @@ window.Vaadin.Flow.comboBoxConnector = {
             }
         }
         else {
-            setTimeout( function(){ 
-                comboBox.$connector.enableClientValidation(enable); 
+            setTimeout( function(){
+                comboBox.$connector.enableClientValidation(enable);
                 }, 10);
         }
     }
-    
+
     const disableClientValidation =  function (combo){
         if ( typeof combo.$checkValidity == 'undefined'){
             combo.$checkValidity = combo.checkValidity;
@@ -207,21 +207,21 @@ window.Vaadin.Flow.comboBoxConnector = {
             combo.validate = function() { return true; };
         }
     }
-    
+
     const disableTextFieldClientValidation =  function (field, comboBox){
         if ( typeof field.$checkValidity == 'undefined'){
             field.$checkValidity = field.checkValidity;
             field.checkValidity = function() { return !comboBox.invalid; };
         }
     }
-    
+
     const enableTextFieldClientValidation = function (field){
         if ( field.$checkValidity ){
             field.checkValidity = field.$checkValidity;
             delete field.$checkValidity;
         }
      }
-    
+
     const enableClientValidation = function (combo){
         if ( combo.$checkValidity ){
             combo.checkValidity = combo.$checkValidity;
@@ -269,5 +269,8 @@ window.Vaadin.Flow.comboBoxConnector = {
     // https://github.com/vaadin/vaadin-combo-box-flow/issues/232
     comboBox.addEventListener('opened-changed', e =>
       e.detail.value && (comboBox.$.overlay._selector._manageFocus = () => {}));
+
+    // Prevent setting the custom value as the 'value'-prop automatically
+    comboBox.addEventListener('custom-value-set', e => e.preventDefault());
   }
 }


### PR DESCRIPTION
If preventDefault is not called, the web component will automatically
set the custom value as the value-property of combo box. This breaks the
Flow component, which uses the key of the currently selected Java bean
as the value-property.

Docs are improved to explain that it's the developer's responsibility to
handle the custom-value-set events, as we can't automatically convert
the custom string to an arbitrary bean type.

Integration tests are added, as previously none existed for this
feature.

Fix #236

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/255)
<!-- Reviewable:end -->
