### PR TITLE
Regenerate selectedItem after setItemLabelGenerator

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/ComboBoxPage.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.bean.SimpleBean;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
@@ -54,6 +55,7 @@ public class ComboBoxPage extends Div {
         createWithUpdatableValue();
         createWithPresetValue();
         createWithButtonRenderer();
+        setLabelGeneratorAfterValue();
     }
 
     private void createExternalSetValue() {
@@ -165,6 +167,18 @@ public class ComboBoxPage extends Div {
         message.setId("updatable-combo-message");
         button.setId("updatable-combo-button");
         add(combo, message, button);
+    }
+
+    private void setLabelGeneratorAfterValue() {
+        ComboBox<SimpleBean> combo = new ComboBox<>();
+        SimpleBean foo = new SimpleBean("foo");
+        combo.setItems(foo);
+        combo.setId("label-generator-after-value");
+
+        combo.setValue(foo);
+        combo.setItemLabelGenerator(SimpleBean::getName);
+
+        add(combo);
     }
 
     private void handleSelection(ComboBox<Title> titles) {

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxPageIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
-import static org.junit.Assert.assertFalse;
-
 import java.util.List;
 
 import org.junit.Assert;
@@ -27,6 +25,8 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
+
+import static org.junit.Assert.assertFalse;
 
 @TestPath("combo-box-test")
 public class ComboBoxPageIT extends AbstractComboBoxIT {
@@ -177,6 +177,13 @@ public class ComboBoxPageIT extends AbstractComboBoxIT {
         Assert.assertEquals("Item 2", getSelectedItemLabel(combo));
         Assert.assertEquals("Value: Item 2 isFromClient: false",
                 message.getText());
+    }
+
+    @Test
+    public void setValue_setLabelGenerator_selectedItemLabelUpdated() {
+        ComboBoxElement combo = $(ComboBoxElement.class)
+                .id("label-generator-after-value");
+        Assert.assertEquals("foo", combo.getSelectedText());
     }
 
 }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -336,6 +336,11 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             }
         }
         super.setValue(value);
+        refreshValue();
+    }
+
+    private void refreshValue() {
+        T value = getValue();
 
         DataKeyMapper<T> keyMapper = getKeyMapper();
         if (value != null && keyMapper.has(value)) {
@@ -641,6 +646,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                 "The item label generator can not be null");
         this.itemLabelGenerator = itemLabelGenerator;
         reset();
+        if (getValue() != null) {
+            refreshValue();
+        }
     }
 
     /**


### PR DESCRIPTION
Otherwise the selectedItem label is not updated, when
setItemLabelGenerator is used after setValue.

fix #195

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/260)
<!-- Reviewable:end -->
