### PR TITLE
Init $connector in ArrayUpdater.initialize and ctor

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -37,7 +37,7 @@ public class DetachReattachPage extends Div {
             add(comboBox);
             remove(comboBox);
         });
-        attach.setId("attach-detach");
+        attachDetach.setId("attach-detach");
 
         add(comboBox, detach, attach, attachDetach);
     }

--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -33,6 +33,12 @@ public class DetachReattachPage extends Div {
         NativeButton attach = new NativeButton("attach", e -> add(comboBox));
         attach.setId("attach");
 
-        add(comboBox, detach, attach);
+        NativeButton attachDetach = new NativeButton("attach-detach", e -> {
+            add(comboBox);
+            remove(comboBox);
+        });
+        attach.setId("attach-detach");
+
+        add(comboBox, detach, attach, attachDetach);
     }
 }

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -40,6 +40,13 @@ public class DetachReattachIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void detachComboBox_reattachRedetach_noClientErrors() {
+        clickButton("detach");
+        clickButton("attach-detach");
+        checkLogsForErrors();
+    }
+
+    @Test
     public void openComboBox_detach_reattach_open_itemsLoaded() {
         combo.openPopup();
         assertRendered("foo");

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -183,7 +183,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         @Override
         public void initialize() {
-            // NO-OP
+            initConnector();
         }
     };
 
@@ -247,7 +247,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         setItemIdPath("key");
         setPageSize(pageSize);
 
-        addAttachListener(e -> initConnector());
+        initConnector();
 
         runBeforeClientResponse(ui -> {
             // If user didn't provide any data, initialize with empty data set.


### PR DESCRIPTION
Moved initConnector to its original position, since attach listener
caused problems. It's still needed in constructor as well to fix another
issue.

This is basically changing the code to a state as if I didn't remove the call in ArrayUpdater.initialize in #252 

fix #270

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/271)
<!-- Reviewable:end -->
