### PR TITLE
Use Element context on JS call to init connector

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -37,7 +37,7 @@ public class DetachReattachPage extends Div {
             add(comboBox);
             remove(comboBox);
         });
-        attach.setId("attach-detach");
+        attachDetach.setId("attach-detach");
 
         add(comboBox, detach, attach, attachDetach);
     }

--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -33,6 +33,12 @@ public class DetachReattachPage extends Div {
         NativeButton attach = new NativeButton("attach", e -> add(comboBox));
         attach.setId("attach");
 
-        add(comboBox, detach, attach);
+        NativeButton attachDetach = new NativeButton("attach-detach", e -> {
+            add(comboBox);
+            remove(comboBox);
+        });
+        attach.setId("attach-detach");
+
+        add(comboBox, detach, attach, attachDetach);
     }
 }

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/ComboBoxIT.java
@@ -75,15 +75,21 @@ public class ComboBoxIT extends TabbedComponentDemoTest {
         openTabAndCheckForErrors("");
         ComboBoxElement comboBox = $(ComboBoxElement.class)
                 .id("disabled-combo-box");
-        WebElement message = layout
-                .findElement(By.id("value-selection-message"));
-        Assert.assertEquals("", message.getText());
+        executeScript("arguments[0].removeAttribute(\"disabled\");", comboBox);
+        comboBox.openPopup();
 
-        executeScript("arguments[0].removeAttribute(\"disabled\");"
-                + "arguments[0].selectedItem = arguments[0].filteredItems[1]",
-                comboBox);
-        message = layout.findElement(By.id("value-selection-message"));
-        Assert.assertEquals("", message.getText());
+        try {
+            waitUntil(driver -> {
+                boolean isLoading = comboBox.getPropertyBoolean("loading");
+                Assert.assertTrue(
+                        "Expected ComboBox to remain in loading state, "
+                                + "as the server should not send data to disabled component.",
+                        isLoading);
+                return !isLoading;
+            }, 2);
+        } catch (TimeoutException e) {
+            // expected
+        }
     }
 
     @Test

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -40,6 +40,13 @@ public class DetachReattachIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void detachComboBox_reattachRedetach_noClientErrors() {
+        clickButton("detach");
+        clickButton("attach-detach");
+        checkLogsForErrors();
+    }
+
+    @Test
     public void openComboBox_detach_reattach_open_itemsLoaded() {
         combo.openPopup();
         assertRendered("foo");

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -499,7 +499,6 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                     getElement().getNode());
         }
 
-        getElement().callJsFunction("$connector.reset");
         scheduleRender();
         setValue(null);
 
@@ -1029,10 +1028,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     }
 
     private void initConnector() {
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.getPage().executeJs(
-                        "window.Vaadin.Flow.comboBoxConnector.initLazy($0)",
-                        getElement()));
+        getElement().executeJs(
+                "window.Vaadin.Flow.comboBoxConnector.initLazy(this)");
     }
 
     private DataKeyMapper<T> getKeyMapper() {

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -936,8 +936,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     @Override
     public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
         super.setRequiredIndicatorVisible(requiredIndicatorVisible);
-        getElement().callJsFunction("$connector.enableClientValidation",
-                !requiredIndicatorVisible);
+        runBeforeClientResponse(ui -> getElement().callJsFunction(
+                "$connector.enableClientValidation",
+                !requiredIndicatorVisible));
     }
 
     /**


### PR DESCRIPTION
This avoids it to be executed when the element doesn't exist in
client-side. Also, removed unnecessary call to connector.reset, which
will be anyway handled through refreshAllData().

Fix #270

This somehow causes "$connector.enableClientValidation" to be called
before connector.init, so it had to be postponed with beforeClientResponse.

Also fixed false-positive disabled IT. It now errored because combo-box
doesn't have filteredItems at all now before the server has responded with
some data.
