### PR TITLE
JsModule path relative to frontend should start with './'

### DIFF
--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -83,7 +83,7 @@ import elemental.json.JsonValue;
  * @author Vaadin Ltd
  */
 @HtmlImport("frontend://flow-component-renderer.html")
-@JsModule("@vaadin/flow-frontend/flow-component-renderer.js")
+@JsModule("./flow-component-renderer.js")
 @JavaScript("frontend://comboBoxConnector.js")
 @JsModule("./comboBoxConnector-es6.js")
 public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>


### PR DESCRIPTION
Concerns https://github.com/vaadin/flow/issues/6177
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/284)
<!-- Reviewable:end -->
