### PR TITLE
fix: send _selectedKey to client only once

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
+++ b/vaadin-combo-box-flow-integration-tests/src/main/java/com/vaadin/flow/component/combobox/test/DetachReattachPage.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.combobox.test;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.Route;
 
 @Route("detach-reattach")
@@ -39,6 +40,16 @@ public class DetachReattachPage extends Div {
         });
         attachDetach.setId("attach-detach");
 
-        add(comboBox, detach, attach, attachDetach);
+        NativeButton setValue = new NativeButton("set value foo",
+                e -> comboBox.setValue("foo"));
+        setValue.setId("set-value");
+
+        Div valueChanges = new Div();
+        valueChanges.setId("value-changes");
+        comboBox.addValueChangeListener(e -> {
+            valueChanges.add(new Paragraph(e.getValue()));
+        });
+
+        add(comboBox, detach, attach, attachDetach, setValue, valueChanges);
     }
 }

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/DetachReattachIT.java
@@ -15,11 +15,13 @@
  */
 package com.vaadin.flow.component.combobox.test;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 @TestPath("detach-reattach")
 public class DetachReattachIT extends AbstractComboBoxIT {
@@ -55,6 +57,26 @@ public class DetachReattachIT extends AbstractComboBoxIT {
         combo = $(ComboBoxElement.class).first();
         combo.openPopup();
         assertLoadedItemsCount("Expected 2 items to be loaded", 2, combo);
+    }
+
+    @Test
+    public void setValueFromServer_selectOtherValue_detach_reattach_valueNotChanged() {
+        clickButton("set-value");
+        assertValueChanges("foo");
+
+        combo.openPopup();
+        combo.selectByText("bar");
+        assertValueChanges("foo", "bar");
+
+        clickButton("detach");
+        clickButton("attach");
+        assertValueChanges("foo", "bar");
+    }
+
+    private void assertValueChanges(String... expected) {
+        String[] valueChanges = $("div").id("value-changes").$("p").all()
+                .stream().map(TestBenchElement::getText).toArray(String[]::new);
+        Assert.assertArrayEquals(expected, valueChanges);
     }
 
 }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -1052,7 +1052,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         dataCommunicator.setRequestedRange(start, length);
         filterSlot.accept(filter);
         // Send (possibly updated) key for the selected value
-        getElement().setProperty("_selectedKey",
+        getElement().executeJs("this._selectedKey=$0",
                 getValue() != null ? getKeyMapper().key(getValue()) : "");
     }
 

--- a/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -247,6 +247,7 @@ window.Vaadin.Flow.comboBoxConnector = {
 
       if (comboBox.selectedItem && comboBox._selectedKey) {
         comboBox.value = comboBox.selectedItem.key = comboBox._selectedKey;
+        delete comboBox._selectedKey;
       }
     }
 


### PR DESCRIPTION
This should be a one-time update when data is requested from the server.
Keeping the value at server-side with setProperty causes it to be sent
to client after value changes, when the _selectedKey is outdated.

Fix #305

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/306)
<!-- Reviewable:end -->
