### PR TITLE
Override combobox _isItemSelected to highlight remapped selected item

### DIFF
--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -75,9 +75,13 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     public void selectItem_changeFilter_properlyFilteredItems() {
         clickButton("set-value");
         stringBox.openPopup();
+
         stringBox.setFilter("Item 11");
+        assertRendered("Item 11");
         assertNotRendered("Item 2");
+
         stringBox.setFilter("Item 111");
+        assertRendered("Item 111");
         assertNotRendered("Item 2");
     }
 

--- a/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
+++ b/vaadin-combo-box-flow-integration-tests/src/test/java/com/vaadin/flow/component/combobox/test/LazyLoadingIT.java
@@ -72,6 +72,16 @@ public class LazyLoadingIT extends AbstractComboBoxIT {
     }
 
     @Test
+    public void selectItem_changeFilter_properlyFilteredItems() {
+        clickButton("set-value");
+        stringBox.openPopup();
+        stringBox.setFilter("Item 11");
+        assertNotRendered("Item 2");
+        stringBox.setFilter("Item 111");
+        assertNotRendered("Item 2");
+    }
+
+    @Test
     public void scrollOverlay_morePagesLoaded_overflowingPagesDiscarded() {
         stringBox.openPopup();
         scrollToItem(stringBox, 50);

--- a/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
+++ b/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js
@@ -244,12 +244,26 @@ window.Vaadin.Flow.comboBoxConnector = {
 
       // Let server know we're done
       comboBox.$server.confirmUpdate(id);
-
-      if (comboBox.selectedItem && comboBox._selectedKey) {
-        comboBox.value = comboBox.selectedItem.key = comboBox._selectedKey;
-        delete comboBox._selectedKey;
-      }
     }
+
+    customElements.whenDefined('vaadin-combo-box').then(() => {
+      const _isItemSelected = comboBox.$.overlay._isItemSelected;
+      // Override comboBox's _isItemSelected logic to handle remapped items
+      comboBox.$.overlay._isItemSelected = (item, selectedItem, itemIdPath) => {
+        let selected = _isItemSelected.call(comboBox, item, selectedItem, itemIdPath);
+
+        if (comboBox._selectedKey) {
+          if (comboBox.filteredItems.indexOf(selectedItem) > -1) {
+            delete comboBox._selectedKey;
+          } else {
+            selected = selected || item.key === comboBox._selectedKey;
+          }
+        }
+
+        return selected;
+      }
+    });
+
 
     comboBox.$connector.enableClientValidation = function( enable ){
         let input = null;


### PR DESCRIPTION
Fixes #304 

This commit removes that hack with dynamically updating the Web Component's `value` / `selectedItem.key` after item remap which turned out to be problematic. The new approach overrides the `_isItemSelected` logic to also consider item remapping when highlighting selection.

By remapping I mean what happens when you scroll away from the currently selected item so that the range which included the selected item gets discarded and later returning to that range so that the selected item is represented by a new object instance with new `key`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box-flow/307)
<!-- Reviewable:end -->
