### PR TITLE
Explicitly remove old dataprovider listener when new one is set

### DIFF
--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -569,7 +569,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
         DataProvider<T, ?> dataProvider = getDataProvider();
-        if (dataProvider != null && dataProviderListener != null) {
+        if (dataProvider != null && dataProviderListener == null) {
             setupDataProviderListener(dataProvider);
         }
     }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -549,7 +549,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
 
-    private void setupDataProviderListener(DataProvider<T, C> dataProvider) {
+    private <C> void setupDataProviderListener(DataProvider<T, C> dataProvider) {
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         if (dataProviderListener != null) {
             dataProviderListener.remove();
@@ -575,8 +575,10 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
-        dataProviderListener.remove();
-        dataProviderListener = null;
+        if (dataProviderListener != null) {
+            dataProviderListener.remove();
+            dataProviderListener = null;
+        }
         super.onDetach(detachEvent);
     }
 
@@ -680,7 +682,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      * @return the data provider used by this ComboBox
      */
     public DataProvider<T, ?> getDataProvider() { // NOSONAR
-        if (getDataCommunicator() != null) {
+        if (dataCommunicator != null) {
             return internalGetDataProvider();
         }
         return dataCommunicator.getDataProvider();

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -552,7 +552,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
 
-    private void setupDataProviderListener(dataProvider) {
+    private void setupDataProviderListener(DataProvider dataProvider) {
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         if (dataProviderListener != null) {
             dataProviderListener.remove();

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -23,8 +23,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
@@ -544,6 +546,14 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
 
+        setupDataProvider(dataProvider);
+        refreshAllData(shouldForceServerSideFiltering);
+
+        userProvidedFilter = UserProvidedFilter.UNDECIDED;
+    }
+
+    private void setupDataProviderListener(dataProvider) {
+        boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         if (dataProviderListener != null) {
             dataProviderListener.remove();
         }
@@ -554,9 +564,21 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                 refreshAllData(shouldForceServerSideFiltering);
             }
         });
-        refreshAllData(shouldForceServerSideFiltering);
+    }
 
-        userProvidedFilter = UserProvidedFilter.UNDECIDED;
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        DataProvider<T, ?> dataProvider = getDataProvider();
+        if (dataProvider != null && dataProviderListener != null) {
+            setupDataProviderListener(dataProvider);
+        }
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        dataProviderListener.remove();
+        super.onDetach(detachEvent);
     }
 
     private void refreshAllData(boolean forceServerSideFiltering) {
@@ -659,6 +681,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      * @return the data provider used by this ComboBox
      */
     public DataProvider<T, ?> getDataProvider() { // NOSONAR
+        if (getDataCommunicator() != null) {
+            return internalGetDataProvider();
+        }
         return dataCommunicator.getDataProvider();
     }
 

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -92,6 +92,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
     private Registration dataProviderListener = null;
+    private boolean shouldForceServerSideFiltering = false;
 
     /**
      * A callback method for fetching items. The callback is provided with a
@@ -544,13 +545,13 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             }
         };
 
+        shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         setupDataProviderListener(dataProvider);
 
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
 
     private <C> void setupDataProviderListener(DataProvider<T, C> dataProvider) {
-        boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         if (dataProviderListener != null) {
             dataProviderListener.remove();
         }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -544,10 +544,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             }
         };
 
-        boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
-
         setupDataProvider(dataProvider);
-        refreshAllData(shouldForceServerSideFiltering);
 
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
@@ -564,6 +561,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
                 refreshAllData(shouldForceServerSideFiltering);
             }
         });
+        refreshAllData(shouldForceServerSideFiltering);
     }
 
     @Override
@@ -578,6 +576,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         dataProviderListener.remove();
+        dataProviderListener = null;
         super.onDetach(detachEvent);
     }
 

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -544,7 +544,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
             }
         };
 
-        setupDataProvider(dataProvider);
+        setupDataProviderListener(dataProvider);
 
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
@@ -683,7 +683,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      */
     public DataProvider<T, ?> getDataProvider() { // NOSONAR
         if (dataCommunicator != null) {
-            return internalGetDataProvider();
+            return getDataProvider();
         }
         return dataCommunicator.getDataProvider();
     }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -89,6 +89,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private static final String PROP_INPUT_ELEMENT_VALUE = "_inputElementValue";
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
+    private dataProviderListener = null;
 
     /**
      * A callback method for fetching items. The callback is provided with a
@@ -543,7 +544,8 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
 
-        dataProvider.addDataProviderListener(e -> {
+        if (dataProviderListener != null) dataProviderListener.remove();
+        dataProviderListener = dataProvider.addDataProviderListener(e -> {
             if (e instanceof DataRefreshEvent) {
                 dataCommunicator.refresh(((DataRefreshEvent<T>) e).getItem());
             } else {

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -685,7 +685,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         if (dataCommunicator != null) {
             return dataCommunicator.getDataProvider();
         }
-        return dataCommunicator.getDataProvider();
+        return null;
     }
 
     /**

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -552,7 +552,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
         userProvidedFilter = UserProvidedFilter.UNDECIDED;
     }
 
-    private void setupDataProviderListener(DataProvider dataProvider) {
+    private void setupDataProviderListener(DataProvider<T, C> dataProvider) {
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
         if (dataProviderListener != null) {
             dataProviderListener.remove();

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -683,7 +683,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
      */
     public DataProvider<T, ?> getDataProvider() { // NOSONAR
         if (dataCommunicator != null) {
-            return getDataProvider();
+            return dataCommunicator.getDataProvider();
         }
         return dataCommunicator.getDataProvider();
     }

--- a/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
+++ b/vaadin-combo-box-flow/src/main/java/com/vaadin/flow/component/combobox/ComboBox.java
@@ -89,7 +89,7 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
     private static final String PROP_INPUT_ELEMENT_VALUE = "_inputElementValue";
     private static final String PROP_SELECTED_ITEM = "selectedItem";
     private static final String PROP_VALUE = "value";
-    private dataProviderListener = null;
+    private Registration dataProviderListener = null;
 
     /**
      * A callback method for fetching items. The callback is provided with a
@@ -544,7 +544,9 @@ public class ComboBox<T> extends GeneratedVaadinComboBox<ComboBox<T>, T>
 
         boolean shouldForceServerSideFiltering = userProvidedFilter == UserProvidedFilter.YES;
 
-        if (dataProviderListener != null) dataProviderListener.remove();
+        if (dataProviderListener != null) {
+            dataProviderListener.remove();
+        }
         dataProviderListener = dataProvider.addDataProviderListener(e -> {
             if (e instanceof DataRefreshEvent) {
                 dataCommunicator.refresh(((DataRefreshEvent<T>) e).getItem());


### PR DESCRIPTION
Explicitly remove old dataprovider listener when new one is set, not doing so can cause memory leakage

Fixes: https://github.com/vaadin/vaadin-combo-box-flow/issues/383